### PR TITLE
Fix backend Dockerfile paths for Buildx context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ backend/coverage
 frontend/coverage
 .DS_Store
 backend/jest-socket-results.json
+*.log
+gh-run*

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ frontend/coverage
 backend/jest-socket-results.json
 *.log
 gh-run*
+latest-runs*
+run*.json
+external/run-16972773386-jobs.json
+external/workflows.txt

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ backend/jest-socket-results.json
 *.log
 gh-run*
 latest-runs*
-run*.json
+*run*.json
 external/run-16972773386-jobs.json
 external/workflows.txt
+external/era-run-16990365551.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,13 +5,13 @@ FROM node:18-alpine AS builder
 WORKDIR /app
 
 # Copy package files
-COPY backend/package*.json ./
+COPY package*.json ./
 
 # Install dependencies
 RUN npm ci
 
 # Copy source code
-COPY backend/ .
+COPY . .
 
 # Build TypeScript
 RUN npm run build

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,8 +27,8 @@ services:
   # Backend with additional test configuration
   backend:
     build:
-      context: .
-      dockerfile: ./backend/Dockerfile
+      context: ./backend
+      dockerfile: Dockerfile
     ports:
       - "5001:5001"
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,8 +104,8 @@ services:
   # Backend - Node.js API with OpenTelemetry tracing
   backend:
     build:
-      context: .
-      dockerfile: ./backend/Dockerfile
+      context: ./backend
+      dockerfile: Dockerfile
     container_name: ai-backend
     ports:
       - "5001:5001"


### PR DESCRIPTION
The GitHub Actions docker job builds with context=backend:\n\n- Previous Dockerfile used:\n  - COPY backend/package*.json ./\n  - COPY backend/ .\n  This fails under Buildx with: '/backend: not found'.\n\n- This change updates to:\n  - COPY package*.json ./\n  - COPY . .\n  which are correct relative to the build context.\n\nThe failing run 16972773386 (job: docker (backend)) shows the error at Dockerfile line with 'COPY backend/ .'.\n