### PR TITLE
Add project_id to GCP auth in docs deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          project_id: kame-457417
 
       - name: Authenticate to Google Cloud (Service Account Key)
         if: env.GCP_SA_KEY != '' && (env.GCP_WORKLOAD_IDENTITY_PROVIDER == '' || env.GCP_SERVICE_ACCOUNT == '')


### PR DESCRIPTION
Specify GCP project ID (kame-457417) for workload identity authentication in the documentation deployment workflow to ensure proper project targeting.

## Pull Request Description

### What does this PR do?

<!-- Briefly describe the changes and their purpose -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD improvements

### Testing

- [ ] Unit tests pass (`npm run test:unit`)
- [ ] Integration tests pass (`npm run test:integration`)
- [ ] Linting passes (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual testing completed (if applicable)

### Code Quality Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of my own code completed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Documentation has been updated (if applicable)
- [ ] No new warnings introduced
- [ ] Coverage threshold maintained or improved

### Component Changes

<!-- Check all that apply -->

- [ ] Backend changes
- [ ] Frontend changes
- [ ] Docker configuration changes
- [ ] CI/CD pipeline changes
- [ ] Documentation changes

### Related Issues

<!-- Link to any related issues -->

Closes #(issue number)

### Screenshots/Videos

<!-- If applicable, add screenshots or videos to help explain your changes -->

### Additional Notes

<!-- Any additional information that reviewers should know -->

### Deployment Notes

<!-- Any special deployment considerations -->

- [ ] Requires database migration
- [ ] Requires environment variable changes
- [ ] Requires dependency updates
- [ ] Backward compatible
