### PR TITLE
fix(agents): pre-dispatch routing gate — joke→youtube handoff on same turn

### DIFF
--- a/backend/src/__tests__/integration/handoff.integration.test.ts
+++ b/backend/src/__tests__/integration/handoff.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration test for the pre-dispatch routing gate.
+ *
+ * The bug this guards against: when a specialist agent (e.g. joke) owned the
+ * conversation and the user asked for something clearly off-domain (e.g.
+ * "show me a youtube video"), the old reactive-handoff code let joke answer
+ * first and only switched to youtube_guru on the NEXT turn. With the router
+ * in place the correct agent must respond on the SAME turn.
+ */
+
+import { AgentService } from '../../agents/agentService';
+
+// Mock OpenAI entirely. Each request returns a response that identifies the
+// agent from its system-prompt. The integration test only cares about which
+// agent was invoked, not the content — so we inspect `agentUsed` on the
+// response.
+jest.mock('openai', () => {
+  return jest.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: jest.fn().mockImplementation(async () => {
+          return {
+            choices: [
+              {
+                message: {
+                  role: 'assistant',
+                  content: 'mock agent response',
+                },
+              },
+            ],
+            usage: { total_tokens: 10 },
+          };
+        }),
+      },
+    },
+  }));
+});
+
+describe('handoff integration — pre-dispatch routing gate', () => {
+  let agentService: AgentService;
+  const userId = 'integration-user';
+
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    agentService = new AgentService();
+  });
+
+  it('hands off from joke to youtube_guru on the SAME turn (regression)', async () => {
+    // Seed conversation: joke agent has owned the context.
+    agentService.initializeConversation(userId, 'joke');
+
+    // User now asks for a YouTube video while joke is the current agent.
+    const result = await agentService.processMessageWithConversation(
+      userId,
+      'show me a youtube video',
+      [],
+      'conv-regress',
+    );
+
+    expect(result.agentUsed).toBe('youtube_guru');
+    expect(result.handoffInfo?.target).toBe('youtube_guru');
+    expect(result.routingDecision?.handoff).toBe(true);
+    // Final conversation context must reflect the new agent.
+    expect(agentService.getCurrentAgent(userId)).toBe('youtube_guru');
+  });
+
+  it('hands off joke → trivia same turn for "random fact"', async () => {
+    agentService.initializeConversation(userId, 'joke');
+
+    const result = await agentService.processMessageWithConversation(
+      userId,
+      'random fact',
+      [],
+      'conv-trivia',
+    );
+
+    expect(result.agentUsed).toBe('trivia');
+    expect(result.handoffInfo?.target).toBe('trivia');
+  });
+
+  it('auto-handoffs hold_agent → entertainment agent on first message', async () => {
+    agentService.initializeConversation(userId, 'hold_agent');
+
+    const result = await agentService.processMessageWithConversation(
+      userId,
+      'hi',
+      [],
+      'conv-hold',
+    );
+
+    // The auto-entertainment override selects one of these at random.
+    const entertainmentAgents = [
+      'joke',
+      'trivia',
+      'gif',
+      'story_teller',
+      'riddle_master',
+      'quote_master',
+      'game_host',
+      'music_guru',
+      'dnd_master',
+    ];
+    expect(entertainmentAgents).toContain(result.agentUsed);
+    expect(result.handoffInfo).toBeDefined();
+  });
+
+  it('stays sticky on an in-domain follow-up (joke → joke)', async () => {
+    agentService.initializeConversation(userId, 'joke');
+
+    const result = await agentService.processMessageWithConversation(
+      userId,
+      'haha that was great',
+      [],
+      'conv-sticky',
+    );
+
+    expect(result.agentUsed).toBe('joke');
+    expect(result.handoffInfo).toBeUndefined();
+    expect(agentService.getCurrentAgent(userId)).toBe('joke');
+  });
+});

--- a/backend/src/agents/__tests__/agentService.test.ts
+++ b/backend/src/agents/__tests__/agentService.test.ts
@@ -1,18 +1,13 @@
-import { AgentService, agentService } from '../agentService';
+import { AgentService } from '../agentService';
 import { classifyMessage } from '../classifier';
 import { getAgent } from '../config';
 import { ConversationManager } from '../conversationManager';
 import { GoalSeekingSystem } from '../goalSeekingSystem';
-import { ragService } from '../ragService';
-import { dndService } from '../dndService';
-import { responseValidator } from '../../validation/responseValidator';
-import { jokeLearningSystem } from '../jokeLearningSystem';
-import { AgentResponse, AgentType } from '../types';
+import { routeMessage } from '../router';
+import { AgentType } from '../types';
 import { Message } from '../../types';
 import {
-  tracer,
   createAgentSpan,
-  createConversationSpan,
   createValidationSpan,
   addSpanEvent,
   setSpanStatus,
@@ -30,6 +25,7 @@ jest.mock('../../validation/responseValidator');
 jest.mock('../jokeLearningSystem');
 jest.mock('../../tracing/tracer');
 jest.mock('../../tracing/contextManager');
+jest.mock('../router');
 
 // Mock OpenAI
 jest.mock('openai', () => ({
@@ -48,6 +44,9 @@ const mockClassifyMessage = classifyMessage as jest.MockedFunction<
   typeof classifyMessage
 >;
 const mockGetAgent = getAgent as jest.MockedFunction<typeof getAgent>;
+const mockRouteMessage = routeMessage as jest.MockedFunction<
+  typeof routeMessage
+>;
 const mockCreateAgentSpan = createAgentSpan as jest.MockedFunction<
   typeof createAgentSpan
 >;
@@ -68,10 +67,7 @@ const mockConversationManager = {
   initializeContext: jest.fn(),
   updateContext: jest.fn(),
   completeHandoff: jest.fn(),
-  getHandoffInfo: jest.fn(),
   cleanup: jest.fn(),
-  generateHandoffMessage: jest.fn(),
-  shouldHandoff: jest.fn(),
 } as any;
 
 const mockGoalSeekingSystem = {
@@ -146,6 +142,22 @@ Object.defineProperty(require('../jokeLearningSystem'), 'jokeLearningSystem', {
   writable: true,
 });
 
+// Helper to build a fresh ConversationContext in the NEW shape (no handoff
+// flags). Test authors can override any field they care about.
+function makeContext(overrides: Partial<any> = {}): any {
+  return {
+    userId: 'test-user',
+    currentAgent: 'general' as AgentType,
+    conversationTopic: 'general',
+    lastMessageTime: new Date(),
+    messageCount: 0,
+    conversationDepth: 0,
+    userSatisfaction: 0.7,
+    agentPerformance: 0.7,
+    ...overrides,
+  };
+}
+
 describe('AgentService', () => {
   let testAgentService: AgentService;
   let mockOpenAI: any;
@@ -211,15 +223,28 @@ describe('AgentService', () => {
     );
 
     mockConversationManager.getContext.mockReturnValue(null);
-    mockConversationManager.initializeContext.mockReturnValue({
-      userId: 'test-user',
-      currentAgent: 'general' as AgentType,
-      lastInteraction: new Date(),
-      messageCount: 0,
-      shouldHandoff: false,
-      handoffTarget: null,
-      handoffReason: null,
-    });
+    mockConversationManager.initializeContext.mockImplementation(
+      (_userId: string, agent: AgentType = 'general') =>
+        makeContext({ currentAgent: agent }),
+    );
+    mockConversationManager.completeHandoff.mockImplementation(
+      (_userId: string, agent: AgentType) =>
+        makeContext({ currentAgent: agent }),
+    );
+    mockConversationManager.updateContext.mockImplementation(
+      (_userId: string, _msg: string, _resp: string, agent: AgentType) =>
+        makeContext({ currentAgent: agent }),
+    );
+
+    // Default: router stays with the current agent (sticky). Individual
+    // tests override this to simulate a handoff decision.
+    mockRouteMessage.mockImplementation(async (_msg, currentAgent) => ({
+      selectedAgent: currentAgent,
+      handoff: false,
+      confidence: 0.5,
+      reason: 'sticky default',
+      source: 'sticky' as const,
+    }));
 
     mockGoalSeekingSystem.generateProactiveActions.mockResolvedValue([]);
     mockGoalSeekingSystem.getUserState.mockReturnValue({});
@@ -687,22 +712,15 @@ describe('AgentService', () => {
         userId,
         'general',
       );
+      expect(mockRouteMessage).toHaveBeenCalledWith('Hello', 'general', []);
       expect(mockConversationManager.updateContext).toHaveBeenCalled();
       expect(result.content).toBe('Conversation response');
     });
 
-    it('should handle existing conversation context', async () => {
-      const existingContext = {
-        userId,
-        currentAgent: 'joke' as AgentType,
-        lastInteraction: new Date(),
-        messageCount: 5,
-        shouldHandoff: false,
-        handoffTarget: null,
-        handoffReason: null,
-      };
-
-      mockConversationManager.getContext.mockReturnValue(existingContext);
+    it('should reuse existing context without re-initializing', async () => {
+      mockConversationManager.getContext.mockReturnValue(
+        makeContext({ currentAgent: 'joke', messageCount: 5 }),
+      );
 
       const result = await testAgentService.processMessageWithConversation(
         userId,
@@ -712,31 +730,25 @@ describe('AgentService', () => {
       );
 
       expect(mockConversationManager.initializeContext).not.toHaveBeenCalled();
+      expect(mockRouteMessage).toHaveBeenCalledWith(
+        'Tell me another joke',
+        'joke',
+        [],
+      );
       expect(result.agentUsed).toBe('joke');
     });
 
-    it('should handle handoff scenario', async () => {
-      const context = {
-        userId,
-        currentAgent: 'general' as AgentType,
-        lastInteraction: new Date(),
-        messageCount: 3,
-        shouldHandoff: false,
-        handoffTarget: null,
-        handoffReason: null,
-      };
-
-      const handoffInfo = {
-        target: 'billing_support' as AgentType,
-        reason: 'User needs billing help',
-        message: 'Transferring you to billing support...',
-      };
-
-      mockConversationManager.getContext.mockReturnValue(context);
-      mockConversationManager.getHandoffInfo.mockReturnValue(handoffInfo);
-      mockConversationManager.completeHandoff.mockReturnValue({
-        ...context,
-        currentAgent: 'billing_support' as AgentType,
+    it('should hand off synchronously when router selects a new agent', async () => {
+      // Current agent is joke; router detects billing intent.
+      mockConversationManager.getContext.mockReturnValue(
+        makeContext({ currentAgent: 'joke', messageCount: 3 }),
+      );
+      mockRouteMessage.mockResolvedValueOnce({
+        selectedAgent: 'billing_support',
+        handoff: true,
+        confidence: 0.95,
+        reason: 'keyword intent match: billing_support (1 keyword)',
+        source: 'keyword',
       });
 
       const result = await testAgentService.processMessageWithConversation(
@@ -746,40 +758,68 @@ describe('AgentService', () => {
         'conv-123',
       );
 
-      expect(result.handoffInfo).toEqual(handoffInfo);
+      expect(result.agentUsed).toBe('billing_support');
+      expect(result.handoffInfo).toBeDefined();
+      expect(result.handoffInfo?.target).toBe('billing_support');
+      expect(result.routingDecision?.source).toBe('keyword');
       expect(mockConversationManager.completeHandoff).toHaveBeenCalledWith(
         userId,
         'billing_support',
       );
     });
 
-    it('should handle entertainment agent handoff directly', async () => {
-      const handoffInfo = {
-        target: 'joke' as AgentType,
-        reason: 'User wants entertainment',
-        message: 'Let me get the joke master for you...',
-      };
-
-      mockConversationManager.getHandoffInfo.mockReturnValue(handoffInfo);
-      mockConversationManager.completeHandoff.mockReturnValue({
-        userId,
-        currentAgent: 'joke' as AgentType,
-        lastInteraction: new Date(),
-        messageCount: 1,
-        shouldHandoff: false,
-        handoffTarget: null,
-        handoffReason: null,
-      });
+    it('should NOT hand off when router returns the sticky current agent', async () => {
+      mockConversationManager.getContext.mockReturnValue(
+        makeContext({ currentAgent: 'joke' }),
+      );
+      // Router default is sticky, no handoff.
 
       const result = await testAgentService.processMessageWithConversation(
         userId,
-        'Tell me a joke',
+        'haha that was great',
         [],
         'conv-123',
       );
 
       expect(result.agentUsed).toBe('joke');
-      expect(result.content).toBe('Conversation response');
+      expect(result.handoffInfo).toBeUndefined();
+      expect(mockConversationManager.completeHandoff).not.toHaveBeenCalled();
+    });
+
+    it('should auto-handoff from hold_agent on first message', async () => {
+      // First message in a hold_agent session must auto-route to one of the
+      // entertainment agents even if the router stayed sticky.
+      mockConversationManager.getContext.mockReturnValue(
+        makeContext({ currentAgent: 'hold_agent', conversationDepth: 0 }),
+      );
+      mockRouteMessage.mockResolvedValueOnce({
+        selectedAgent: 'hold_agent',
+        handoff: false,
+        confidence: 0.5,
+        reason: 'sticky default',
+        source: 'sticky',
+      });
+
+      const result = await testAgentService.processMessageWithConversation(
+        userId,
+        'hi',
+        [],
+        'conv-123',
+      );
+
+      const entertainmentAgents = [
+        'joke',
+        'trivia',
+        'gif',
+        'story_teller',
+        'riddle_master',
+        'quote_master',
+        'game_host',
+        'music_guru',
+        'dnd_master',
+      ];
+      expect(entertainmentAgents).toContain(result.agentUsed);
+      expect(result.handoffInfo).toBeDefined();
     });
   });
 
@@ -795,15 +835,9 @@ describe('AgentService', () => {
     });
 
     it('should combine conversation and goal-seeking systems', async () => {
-      mockConversationManager.getContext.mockReturnValue({
-        userId,
-        currentAgent: 'general' as AgentType,
-        lastInteraction: new Date(),
-        messageCount: 1,
-        shouldHandoff: false,
-        handoffTarget: null,
-        handoffReason: null,
-      });
+      mockConversationManager.getContext.mockReturnValue(
+        makeContext({ currentAgent: 'general' }),
+      );
 
       mockGoalSeekingSystem.generateProactiveActions.mockResolvedValue([]);
 
@@ -821,15 +855,7 @@ describe('AgentService', () => {
     });
 
     it('should prioritize goal-seeking when agent is forced', async () => {
-      const contextObject = {
-        userId,
-        currentAgent: 'trivia' as AgentType,
-        lastInteraction: new Date(),
-        messageCount: 1,
-        shouldHandoff: false,
-        handoffTarget: null,
-        handoffReason: null,
-      };
+      const contextObject = makeContext({ currentAgent: 'trivia' });
 
       // Mock both updateContext and getContext to return a context object
       mockConversationManager.updateContext.mockReturnValue(contextObject);
@@ -892,17 +918,8 @@ describe('AgentService', () => {
       expect(mockConversationManager.getContext).toHaveBeenCalledWith(userId);
     });
 
-    it('should force agent handoff', () => {
-      const context = {
-        userId,
-        currentAgent: 'general' as AgentType,
-        lastInteraction: new Date(),
-        messageCount: 1,
-        shouldHandoff: false,
-        handoffTarget: null,
-        handoffReason: null,
-      };
-
+    it('should force agent handoff synchronously by calling completeHandoff', () => {
+      const context = makeContext({ currentAgent: 'general' });
       mockConversationManager.getContext.mockReturnValue(context);
 
       testAgentService.forceAgentHandoff(
@@ -911,21 +928,32 @@ describe('AgentService', () => {
         'Manual override',
       );
 
-      expect(context.shouldHandoff).toBe(true);
-      expect(context.handoffTarget).toBe('billing_support');
-      expect(context.handoffReason).toBe('Manual override');
+      expect(mockConversationManager.completeHandoff).toHaveBeenCalledWith(
+        userId,
+        'billing_support',
+      );
+    });
+
+    it('should initialize context on force handoff when no context exists', () => {
+      mockConversationManager.getContext.mockReturnValue(null);
+
+      testAgentService.forceAgentHandoff(
+        userId,
+        'billing_support',
+        'Manual override',
+      );
+
+      expect(mockConversationManager.initializeContext).toHaveBeenCalledWith(
+        userId,
+        'billing_support',
+      );
+      expect(mockConversationManager.completeHandoff).not.toHaveBeenCalled();
     });
 
     it('should get current agent', () => {
-      mockConversationManager.getContext.mockReturnValue({
-        userId,
-        currentAgent: 'joke' as AgentType,
-        lastInteraction: new Date(),
-        messageCount: 1,
-        shouldHandoff: false,
-        handoffTarget: null,
-        handoffReason: null,
-      });
+      mockConversationManager.getContext.mockReturnValue(
+        makeContext({ currentAgent: 'joke' }),
+      );
 
       const currentAgent = testAgentService.getCurrentAgent(userId);
       expect(currentAgent).toBe('joke');
@@ -939,7 +967,7 @@ describe('AgentService', () => {
     });
 
     it('should initialize conversation', () => {
-      const context = testAgentService.initializeConversation(userId, 'trivia');
+      testAgentService.initializeConversation(userId, 'trivia');
 
       expect(mockConversationManager.initializeContext).toHaveBeenCalledWith(
         userId,

--- a/backend/src/agents/__tests__/router.test.ts
+++ b/backend/src/agents/__tests__/router.test.ts
@@ -1,0 +1,170 @@
+import { routeMessage, logRoutingDecision } from '../router';
+import { classifyMessage } from '../classifier';
+import { AgentType } from '../types';
+
+jest.mock('../classifier');
+jest.mock('../../tracing/tracer', () => ({
+  addSpanEvent: jest.fn(),
+}));
+
+const mockClassifyMessage = classifyMessage as jest.MockedFunction<
+  typeof classifyMessage
+>;
+
+describe('routeMessage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.OPENAI_API_KEY;
+    // Default classifier fallback: no confident answer. Individual tests
+    // override when they want classifier-path behavior.
+    mockClassifyMessage.mockResolvedValue({
+      agentType: 'general' as AgentType,
+      confidence: 0.3,
+      reasoning: 'fallback',
+    });
+  });
+
+  it('routes "show me a youtube video" to youtube_guru as a handoff from joke', async () => {
+    const decision = await routeMessage('show me a youtube video', 'joke');
+    expect(decision.selectedAgent).toBe('youtube_guru');
+    expect(decision.handoff).toBe(true);
+    expect(decision.source).toBe('keyword');
+  });
+
+  it('routes "tell me a joke" to joke even from general', async () => {
+    const decision = await routeMessage('tell me a joke', 'general');
+    expect(decision.selectedAgent).toBe('joke');
+    expect(decision.handoff).toBe(true);
+    expect(decision.source).toBe('keyword');
+  });
+
+  it('routes "show me a gif" to gif from joke', async () => {
+    const decision = await routeMessage('show me a gif', 'joke');
+    expect(decision.selectedAgent).toBe('gif');
+    expect(decision.handoff).toBe(true);
+    expect(decision.source).toBe('keyword');
+  });
+
+  it('routes "random fact" to trivia', async () => {
+    const decision = await routeMessage('random fact', 'general');
+    expect(decision.selectedAgent).toBe('trivia');
+    expect(decision.handoff).toBe(true);
+    expect(decision.source).toBe('keyword');
+  });
+
+  it('routes "roll a d20" to dnd_master from joke', async () => {
+    const decision = await routeMessage('roll a d20', 'joke');
+    expect(decision.selectedAgent).toBe('dnd_master');
+    expect(decision.handoff).toBe(true);
+    expect(decision.source).toBe('keyword');
+  });
+
+  it('stays sticky on short acknowledgements with no keywords', async () => {
+    const decision = await routeMessage("that's nice", 'joke');
+    expect(decision.selectedAgent).toBe('joke');
+    expect(decision.handoff).toBe(false);
+    expect(decision.source).toBe('sticky');
+  });
+
+  it('tie-break: "funny youtube video" — youtube_guru wins over joke by priority', async () => {
+    // Both buckets match ("funny" → joke, "youtube video" → youtube_guru).
+    // PRIORITY order puts youtube_guru first, so it must win.
+    const decision = await routeMessage('funny youtube video', 'general');
+    expect(decision.selectedAgent).toBe('youtube_guru');
+    expect(decision.source).toBe('keyword');
+  });
+
+  it('uses classifier result when no keyword matches and confidence is high', async () => {
+    mockClassifyMessage.mockResolvedValueOnce({
+      agentType: 'website_support' as AgentType,
+      confidence: 0.8,
+      reasoning: 'classified: support intent',
+    });
+
+    const decision = await routeMessage(
+      'my dashboard looks broken after the update',
+      'general',
+    );
+
+    expect(decision.selectedAgent).toBe('website_support');
+    expect(decision.handoff).toBe(true);
+    expect(decision.source).toBe('classifier');
+  });
+
+  it('falls through to sticky when classifier returns general', async () => {
+    mockClassifyMessage.mockResolvedValueOnce({
+      agentType: 'general' as AgentType,
+      confidence: 0.8,
+      reasoning: 'no specialist needed',
+    });
+
+    const decision = await routeMessage('just thinking out loud here', 'joke');
+    expect(decision.selectedAgent).toBe('joke');
+    expect(decision.handoff).toBe(false);
+    expect(decision.source).toBe('sticky');
+  });
+
+  it('falls through to sticky when classifier throws', async () => {
+    mockClassifyMessage.mockRejectedValueOnce(new Error('classifier exploded'));
+    const decision = await routeMessage('random free-form message', 'trivia');
+    expect(decision.selectedAgent).toBe('trivia');
+    expect(decision.source).toBe('sticky');
+  });
+
+  it('treats empty input as a no-op sticky decision', async () => {
+    const decision = await routeMessage('   ', 'joke');
+    expect(decision.selectedAgent).toBe('joke');
+    expect(decision.handoff).toBe(false);
+    expect(decision.source).toBe('sticky');
+    expect(mockClassifyMessage).not.toHaveBeenCalled();
+  });
+
+  it('never flags handoff when the keyword-selected agent equals currentAgent', async () => {
+    const decision = await routeMessage('tell me a joke', 'joke');
+    expect(decision.selectedAgent).toBe('joke');
+    expect(decision.handoff).toBe(false);
+    expect(decision.source).toBe('keyword');
+  });
+});
+
+describe('logRoutingDecision', () => {
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    logSpy.mockClear();
+  });
+
+  afterAll(() => {
+    logSpy.mockRestore();
+  });
+
+  it('logs a handoff line when decision.handoff is true', () => {
+    logRoutingDecision(
+      {
+        selectedAgent: 'youtube_guru' as AgentType,
+        handoff: true,
+        confidence: 0.9,
+        reason: 'keyword match',
+        source: 'keyword',
+      },
+      { currentAgent: 'joke' as AgentType, userId: 'u1' },
+    );
+    const calls = logSpy.mock.calls.flat().join('\n');
+    expect(calls).toMatch(/ROUTER handoff joke → youtube_guru/);
+  });
+
+  it('logs a stick line when decision.handoff is false', () => {
+    logRoutingDecision(
+      {
+        selectedAgent: 'joke' as AgentType,
+        handoff: false,
+        confidence: 0.5,
+        reason: 'sticky default',
+        source: 'sticky',
+      },
+      { currentAgent: 'joke' as AgentType, userId: 'u1' },
+    );
+    const calls = logSpy.mock.calls.flat().join('\n');
+    expect(calls).toMatch(/ROUTER stick with joke/);
+  });
+});

--- a/backend/src/agents/agentService.ts
+++ b/backend/src/agents/agentService.ts
@@ -12,16 +12,14 @@ import {
 } from './conversationManager';
 import { ragService } from './ragService';
 import { dndService } from './dndService';
+import { routeMessage, logRoutingDecision, RoutingDecision } from './router';
 import {
-  tracer,
   createAgentSpan,
-  createConversationSpan,
   createValidationSpan,
   addSpanEvent,
   setSpanStatus,
   endSpan,
 } from '../tracing/tracer';
-import { tracingContextManager } from '../tracing/contextManager';
 
 export class AgentService {
   private goalSeekingSystem: GoalSeekingSystem;
@@ -712,7 +710,14 @@ To get real AI responses, please set your OPENAI_API_KEY environment variable.`;
 
   // ===== CONVERSATION MANAGEMENT METHODS =====
 
-  // Enhanced message processing with conversation continuity and intelligent handoffs
+  /**
+   * Enhanced message processing with pre-dispatch routing.
+   *
+   * Handoff decisions are made BEFORE the message is dispatched to an agent,
+   * so the user's request is always handled by the right agent on the same
+   * turn. Previously the handoff was detected after the current agent had
+   * already replied, producing a one-turn lag.
+   */
   async processMessageWithConversation(
     userId: string,
     message: string,
@@ -721,34 +726,33 @@ To get real AI responses, please set your OPENAI_API_KEY environment variable.`;
   ): Promise<
     AgentResponse & {
       handoffInfo?: { target: AgentType; reason: string; message: string };
+      routingDecision?: RoutingDecision;
     }
   > {
     // Get or initialize conversation context
     let context = this.conversationManager.getContext(userId);
     if (!context) {
-      // Start with general agent if no context exists
       context = this.conversationManager.initializeContext(userId, 'general');
     }
 
-    // Current agent from conversation context
-    let currentAgent = context.currentAgent;
+    const previousAgent = context.currentAgent;
 
-    // Check if we need to handoff before processing
-    const handoffInfo = this.conversationManager.getHandoffInfo(userId);
-    if (handoffInfo) {
-      console.log(
-        `🔄 Agent handoff detected for user ${userId}: ${context.currentAgent} → ${handoffInfo.target} (${handoffInfo.reason})`,
-      );
+    // === Pre-dispatch routing ===
+    let decision = await routeMessage(
+      message,
+      previousAgent,
+      conversationHistory,
+    );
 
-      // Complete the handoff
-      context = this.conversationManager.completeHandoff(
-        userId,
-        handoffInfo.target,
-      );
-      currentAgent = handoffInfo.target;
-
-      // For entertainment agents, process the message directly with the target agent instead of returning handoff message
-      const entertainmentAgents = [
+    // Preserve the long-standing "hold_agent auto-handoff to entertainment
+    // on the first message" behavior. This is intentionally handled here
+    // rather than in the router so the router stays pure and easily testable.
+    if (
+      previousAgent === 'hold_agent' &&
+      context.conversationDepth === 0 &&
+      decision.selectedAgent === 'hold_agent'
+    ) {
+      const entertainmentAgents: AgentType[] = [
         'joke',
         'trivia',
         'gif',
@@ -759,66 +763,71 @@ To get real AI responses, please set your OPENAI_API_KEY environment variable.`;
         'music_guru',
         'dnd_master',
       ];
-      if (entertainmentAgents.includes(handoffInfo.target)) {
-        console.log(
-          `🎭 Processing message directly with entertainment agent: ${handoffInfo.target}`,
-        );
-
-        // Process message with the entertainment agent
-        const response = await this.processMessage(
-          message,
-          conversationHistory,
-          handoffInfo.target,
-          conversationId,
-          userId,
-        );
-
-        // Update conversation context with the interaction
-        this.conversationManager.updateContext(
-          userId,
-          message,
-          response.content,
-          handoffInfo.target,
-        );
-
-        return {
-          ...response,
-          agentUsed: handoffInfo.target, // Make sure the response shows it came from the entertainment agent
-        };
-      }
-
-      // For non-entertainment agents, return handoff message first
-      return {
-        content: handoffInfo.message,
-        agentUsed: 'general', // Handoff messages come from general agent
+      const randomAgent =
+        entertainmentAgents[
+          Math.floor(Math.random() * entertainmentAgents.length)
+        ];
+      console.log(
+        `🎲 AUTOMATIC ENTERTAINMENT HANDOFF: Selected random agent '${randomAgent}' while user is on hold`,
+      );
+      decision = {
+        selectedAgent: randomAgent,
+        handoff: true,
         confidence: 1.0,
-        handoffInfo,
+        reason: `No specialists available - auto-connecting you to ${randomAgent} while you wait`,
+        source: 'sticky',
       };
     }
 
-    // Process message with current agent
+    logRoutingDecision(decision, {
+      userId,
+      conversationId,
+      currentAgent: previousAgent,
+      messagePreview: message.substring(0, 80),
+    });
+
+    // If the router chose a new agent, complete the handoff now so that
+    // per-agent metrics (depth, performance) reset before dispatch.
+    if (decision.handoff) {
+      context = this.conversationManager.completeHandoff(
+        userId,
+        decision.selectedAgent,
+      );
+    }
+
+    // Dispatch with the forced agent from the routing decision. Passing
+    // `decision.selectedAgent` prevents `processMessage` from classifying
+    // the message again (avoiding double-classification).
     const response = await this.processMessage(
       message,
       conversationHistory,
-      currentAgent,
+      decision.selectedAgent,
       conversationId,
       userId,
     );
 
-    // Update conversation context with the interaction
+    // Update conversation context with the interaction using the agent
+    // that actually produced the response.
     this.conversationManager.updateContext(
       userId,
       message,
       response.content,
-      currentAgent,
+      decision.selectedAgent,
     );
 
-    // Check if handoff is now needed after this interaction
-    const newHandoffInfo = this.conversationManager.getHandoffInfo(userId);
+    const handoffInfo = decision.handoff
+      ? {
+          target: decision.selectedAgent,
+          reason: decision.reason,
+          message: `Connecting you to our ${getAgent(decision.selectedAgent).name}.`,
+        }
+      : undefined;
 
     return {
       ...response,
-      handoffInfo: newHandoffInfo || undefined,
+      agentUsed: decision.selectedAgent,
+      handoffInfo,
+      routingDecision: decision,
     };
   }
 
@@ -827,18 +836,28 @@ To get real AI responses, please set your OPENAI_API_KEY environment variable.`;
     return this.conversationManager.getContext(userId);
   }
 
-  // Force agent handoff (manual override)
+  /**
+   * Force a handoff to `targetAgent` immediately.
+   *
+   * With the pre-dispatch router, we no longer queue a handoff to fire on
+   * the next turn — we complete it right now so the next `processMessage`
+   * call for this user sees the new agent. The `reason` parameter is kept
+   * for API compatibility and logging.
+   */
   forceAgentHandoff(
     userId: string,
     targetAgent: AgentType,
     reason = 'Manual override',
   ): void {
     const context = this.conversationManager.getContext(userId);
-    if (context) {
-      context.shouldHandoff = true;
-      context.handoffTarget = targetAgent;
-      context.handoffReason = reason;
+    if (!context) {
+      this.conversationManager.initializeContext(userId, targetAgent);
+    } else {
+      this.conversationManager.completeHandoff(userId, targetAgent);
     }
+    console.log(
+      `🛠️ forceAgentHandoff: user=${userId} target=${targetAgent} reason="${reason}"`,
+    );
   }
 
   // Get current agent for a user based on conversation context

--- a/backend/src/agents/config.ts
+++ b/backend/src/agents/config.ts
@@ -87,7 +87,11 @@ GOAL-SEEKING BEHAVIOR:
 - Build a personalized comedy profile for each user
 - Strive to become the perfect comedian for each individual
 
-Remember: You're not just telling jokes - you're learning to be the best possible comedian for each unique user!`,
+Remember: You're not just telling jokes - you're learning to be the best possible comedian for each unique user!
+
+SCOPE & DEFERRAL:
+- Your domain is jokes, puns, wordplay, and comedic one-liners. If the user clearly asks for something else — a YouTube video, a GIF, a trivia fact, a story, a riddle, a quote, a music recommendation, a D&D session, or account/billing/website help — DO NOT attempt to fulfill it yourself.
+- Reply in one short line acknowledging the shift (e.g. "Let me hand you off to our YouTube specialist.") and stop. The orchestrator will route the user to the right specialist on this same turn.`,
     model: 'gpt-3.5-turbo',
     temperature: 0.8,
     maxTokens: 1000,
@@ -135,7 +139,11 @@ Topics you excel at:
 - Food and culinary facts
 - Technology and inventions
 
-Remember: You're here to spark curiosity and make learning fun through amazing facts and trivia! Always deliver facts immediately when asked!`,
+Remember: You're here to spark curiosity and make learning fun through amazing facts and trivia! Always deliver facts immediately when asked!
+
+SCOPE & DEFERRAL:
+- Your domain is trivia, facts, and educational curiosities. If the user clearly asks for jokes, YouTube videos, GIFs, stories, riddles, quotes, music, D&D, or account/billing/website help, DO NOT attempt to fulfill it yourself.
+- Reply in one short line (e.g. "Let me hand you off to our Joke Master.") and stop. The orchestrator will route the user to the right specialist on this same turn.`,
     model: 'gpt-3.5-turbo',
     temperature: 0.7,
     maxTokens: 1000,
@@ -196,7 +204,11 @@ Want another GIF? I've got tons more where that came from! 🎉"
 - Ensure GIFs match the emotional tone requested
 - Keep GIF descriptions accurate and fun
 
-Remember: You're the master of Giphy entertainment! Every GIF should feel like the perfect visual treat for the moment!`,
+Remember: You're the master of Giphy entertainment! Every GIF should feel like the perfect visual treat for the moment!
+
+SCOPE & DEFERRAL:
+- Your domain is GIFs, memes, and reaction images. If the user clearly asks for jokes, YouTube videos, trivia, stories, riddles, quotes, music, D&D, or account/billing/website help, DO NOT attempt to fulfill it yourself.
+- Reply in one short line (e.g. "Let me hand you off to our YouTube specialist.") and stop. The orchestrator will route the user to the right specialist on this same turn.`,
     model: 'gpt-3.5-turbo',
     temperature: 0.8,
     maxTokens: 600,
@@ -592,7 +604,11 @@ PERSONALITY TRAITS:
 - Patient with interactive elements
 - Encouraging of imagination
 
-Your goal is to transport users into engaging mini-adventures that make their wait time fly by!`,
+Your goal is to transport users into engaging mini-adventures that make their wait time fly by!
+
+SCOPE & DEFERRAL:
+- Your domain is short interactive stories. If the user clearly asks for jokes, YouTube videos, GIFs, trivia, riddles, quotes, music, D&D sessions, or account/billing/website help, DO NOT attempt to fulfill it yourself.
+- Reply in one short line (e.g. "Let me hand you off to our specialist.") and stop. The orchestrator will route the user to the right agent on this same turn.`,
     model: 'gpt-3.5-turbo',
     temperature: 0.9,
     maxTokens: 1000,
@@ -652,7 +668,11 @@ HINT SYSTEM:
 - Third hint: Almost gives it away
 - Always ask if they want to keep trying before revealing
 
-Remember: Your goal is mental engagement and fun, not frustration. Keep users actively thinking and entertained!`,
+Remember: Your goal is mental engagement and fun, not frustration. Keep users actively thinking and entertained!
+
+SCOPE & DEFERRAL:
+- Your domain is riddles, brain teasers, and word puzzles. If the user clearly asks for jokes, YouTube videos, GIFs, trivia, stories, quotes, music, D&D, or account/billing/website help, DO NOT attempt to fulfill it yourself.
+- Reply in one short line (e.g. "Let me hand you off to our specialist.") and stop. The orchestrator will route the user to the right agent on this same turn.`,
     model: 'gpt-3.5-turbo',
     temperature: 0.7,
     maxTokens: 900,
@@ -715,7 +735,11 @@ MOOD MATCHING:
 - Success quotes for motivation
 - Patience quotes specifically for wait times
 
-Remember: Your quotes should feel personally selected and meaningful, not just random. Make each quote feel like a small gift of wisdom or joy!`,
+Remember: Your quotes should feel personally selected and meaningful, not just random. Make each quote feel like a small gift of wisdom or joy!
+
+SCOPE & DEFERRAL:
+- Your domain is quotes, aphorisms, and inspirational sayings. If the user clearly asks for jokes, YouTube videos, GIFs, trivia, stories, riddles, music, D&D, or account/billing/website help, DO NOT attempt to fulfill it yourself.
+- Reply in one short line (e.g. "Let me hand you off to our specialist.") and stop. The orchestrator will route the user to the right agent on this same turn.`,
     model: 'gpt-3.5-turbo',
     temperature: 0.6,
     maxTokens: 800,
@@ -860,7 +884,11 @@ PERSONALIZATION:
 - Create themed recommendations for specific situations
 - Suggest music for different parts of their day
 
-Remember: Music is deeply personal and emotional. Your recommendations should feel thoughtful and curated, not generic. Help users discover their next favorite song or artist!`,
+Remember: Music is deeply personal and emotional. Your recommendations should feel thoughtful and curated, not generic. Help users discover their next favorite song or artist!
+
+SCOPE & DEFERRAL:
+- Your domain is music recommendations, artists, and playlists. If the user clearly asks for jokes, YouTube videos, GIFs, trivia, stories, riddles, quotes, D&D, or account/billing/website help, DO NOT attempt to fulfill it yourself.
+- Reply in one short line (e.g. "Let me hand you off to our specialist.") and stop. The orchestrator will route the user to the right agent on this same turn.`,
     model: 'gpt-3.5-turbo',
     temperature: 0.7,
     maxTokens: 1100,
@@ -947,7 +975,11 @@ Want another video? I've got tons more entertainment ready to go!"
 - Provide realistic duration estimates
 - The frontend will automatically convert these into proper YouTube embeds
 
-Remember: Your goal is to provide immediate entertainment relief through actual embedded YouTube videos! Make people forget they're waiting by giving them something genuinely funny to watch right in the chat!`,
+Remember: Your goal is to provide immediate entertainment relief through actual embedded YouTube videos! Make people forget they're waiting by giving them something genuinely funny to watch right in the chat!
+
+SCOPE & DEFERRAL:
+- Your domain is YouTube videos and embedded video content. If the user clearly asks for jokes (text-only), GIFs, trivia facts, stories, riddles, quotes, music recommendations, D&D, or account/billing/website help, DO NOT attempt to fulfill it yourself.
+- Reply in one short line (e.g. "Let me hand you off to our Joke Master.") and stop. The orchestrator will route the user to the right specialist on this same turn.`,
     model: 'gpt-3.5-turbo',
     temperature: 0.8,
     maxTokens: 1200,
@@ -1055,7 +1087,11 @@ Always use the service functions for consistent, authentic D&D experience.
 
 Choose your adventure!"
 
-Remember: Keep everything fast-paced, fun, and accessible for both D&D veterans and newcomers. The goal is quick entertainment with that classic D&D flavor!`,
+Remember: Keep everything fast-paced, fun, and accessible for both D&D veterans and newcomers. The goal is quick entertainment with that classic D&D flavor!
+
+SCOPE & DEFERRAL:
+- Your domain is D&D-flavored interactive play (dice rolls, characters, encounters). If the user clearly asks for jokes, YouTube videos, GIFs, trivia, stories, riddles, quotes, music, or account/billing/website help, DO NOT attempt to fulfill it yourself.
+- Reply in one short line (e.g. "Let me hand you off to our specialist.") and stop. The orchestrator will route the user to the right agent on this same turn.`,
     model: 'gpt-4',
     temperature: 0.8,
     maxTokens: 1500,

--- a/backend/src/agents/conversationManager.ts
+++ b/backend/src/agents/conversationManager.ts
@@ -1,6 +1,13 @@
 import { AgentType } from './types';
 import { Message } from '../types';
 
+/**
+ * Tracks per-user conversation state.
+ *
+ * NOTE: handoff decisions are no longer stored here. They are computed
+ * pre-dispatch by `router.ts` on every incoming message, which keeps the
+ * state machine simpler and fixes the "handoff one turn late" bug.
+ */
 export interface ConversationContext {
   userId: string;
   currentAgent: AgentType;
@@ -10,21 +17,6 @@ export interface ConversationContext {
   conversationDepth: number; // How deep the conversation is with current agent
   userSatisfaction: number; // 0-1 scale
   agentPerformance: number; // 0-1 scale based on user responses
-  shouldHandoff: boolean;
-  handoffReason?: string;
-  handoffTarget?: AgentType;
-}
-
-export interface HandoffTrigger {
-  type:
-    | 'explicit_request'
-    | 'topic_shift'
-    | 'performance_decline'
-    | 'expertise_mismatch'
-    | 'conversation_stagnation';
-  confidence: number;
-  targetAgent?: AgentType;
-  reason: string;
 }
 
 export class ConversationManager {
@@ -45,14 +37,14 @@ export class ConversationManager {
       conversationDepth: 0,
       userSatisfaction: 0.7, // Start with neutral satisfaction
       agentPerformance: 0.7, // Start with neutral performance
-      shouldHandoff: false,
     };
 
     this.contexts.set(userId, context);
     return context;
   }
 
-  // Update conversation context based on user message
+  // Update conversation context based on user message. This no longer
+  // performs handoff detection — the router handles that pre-dispatch.
   updateContext(
     userId: string,
     userMessage: string,
@@ -64,6 +56,13 @@ export class ConversationManager {
       context = this.initializeContext(userId, currentAgent);
     }
 
+    // If the router selected a different agent than what context had, make
+    // sure we track that — but do NOT reset depth here; `completeHandoff`
+    // is the dedicated call site for that.
+    if (context.currentAgent !== currentAgent) {
+      context.currentAgent = currentAgent;
+    }
+
     // Update basic metrics
     context.lastMessageTime = new Date();
     context.messageCount++;
@@ -71,18 +70,6 @@ export class ConversationManager {
 
     // Analyze message for topic and satisfaction
     this.analyzeMessage(context, userMessage, agentResponse);
-
-    // Check for handoff triggers
-    const handoffTrigger = this.detectHandoffTriggers(
-      context,
-      userMessage,
-      currentAgent,
-    );
-    if (handoffTrigger) {
-      context.shouldHandoff = true;
-      context.handoffReason = handoffTrigger.reason;
-      context.handoffTarget = handoffTrigger.targetAgent;
-    }
 
     this.contexts.set(userId, context);
     return context;
@@ -92,7 +79,7 @@ export class ConversationManager {
   private analyzeMessage(
     context: ConversationContext,
     userMessage: string,
-    agentResponse: string,
+    _agentResponse: string,
   ): void {
     const lowerMessage = userMessage.toLowerCase();
 
@@ -167,376 +154,6 @@ export class ConversationManager {
     }
   }
 
-  // Detect when an agent should hand off to another
-  private detectHandoffTriggers(
-    context: ConversationContext,
-    userMessage: string,
-    currentAgent: AgentType,
-  ): HandoffTrigger | null {
-    const lowerMessage = userMessage.toLowerCase();
-
-    // **AUTOMATIC ENTERTAINMENT HANDOFF**: If this is the first message TO hold_agent, immediately handoff to random entertainment
-    // This triggers handoff during the initial message processing, not after
-    // HIGHEST PRIORITY - this overrides all other detections for hold_agent
-    if (currentAgent === 'hold_agent' && context.conversationDepth === 1) {
-      const entertainmentAgents: AgentType[] = [
-        'joke',
-        'trivia',
-        'gif',
-        'story_teller',
-        'riddle_master',
-        'quote_master',
-        'game_host',
-        'music_guru',
-        'dnd_master',
-      ];
-      const randomAgent =
-        entertainmentAgents[
-          Math.floor(Math.random() * entertainmentAgents.length)
-        ];
-
-      console.log(
-        `🎲 AUTOMATIC ENTERTAINMENT HANDOFF: Selected random agent '${randomAgent}' from ${entertainmentAgents.length} available entertainment agents`,
-      );
-
-      return {
-        type: 'explicit_request',
-        confidence: 1.0,
-        targetAgent: randomAgent,
-        reason: `No specialists available - automatically connecting you to our ${randomAgent} agent for entertainment while you wait`,
-      };
-    }
-
-    // Explicit requests for different agent types (only for non-hold agents)
-    if (lowerMessage.includes('tell me a joke') && currentAgent !== 'joke') {
-      return {
-        type: 'explicit_request',
-        confidence: 0.9,
-        targetAgent: 'joke',
-        reason: 'User explicitly requested humor',
-      };
-    }
-
-    if (
-      (lowerMessage.includes('fact') ||
-        lowerMessage.includes('trivia') ||
-        lowerMessage.includes('learn')) &&
-      currentAgent !== 'trivia'
-    ) {
-      return {
-        type: 'explicit_request',
-        confidence: 0.8,
-        targetAgent: 'trivia',
-        reason: 'User requested educational content',
-      };
-    }
-
-    if (
-      (lowerMessage.includes('gif') ||
-        lowerMessage.includes('meme') ||
-        lowerMessage.includes('visual')) &&
-      currentAgent !== 'gif'
-    ) {
-      return {
-        type: 'explicit_request',
-        confidence: 0.8,
-        targetAgent: 'gif',
-        reason: 'User requested visual entertainment',
-      };
-    }
-
-    if (
-      (lowerMessage.includes('youtube') ||
-        lowerMessage.includes('video') ||
-        lowerMessage.includes('viral') ||
-        lowerMessage.includes('show me something funny') ||
-        lowerMessage.includes('entertaining video')) &&
-      currentAgent !== 'youtube_guru'
-    ) {
-      return {
-        type: 'explicit_request',
-        confidence: 0.9,
-        targetAgent: 'youtube_guru',
-        reason: 'User requested YouTube videos or viral content',
-      };
-    }
-
-    if (
-      (lowerMessage.includes('d&d') ||
-        lowerMessage.includes('dnd') ||
-        lowerMessage.includes('dungeons and dragons') ||
-        lowerMessage.includes('rpg') ||
-        lowerMessage.includes('dice') ||
-        lowerMessage.includes('character') ||
-        lowerMessage.includes('adventure') ||
-        lowerMessage.includes('dungeon master') ||
-        lowerMessage.includes('roll dice')) &&
-      currentAgent !== 'dnd_master'
-    ) {
-      return {
-        type: 'explicit_request',
-        confidence: 0.9,
-        targetAgent: 'dnd_master',
-        reason: 'User requested D&D RPG experience',
-      };
-    }
-
-    // Topic shift detection
-    const topicMismatch = this.detectTopicMismatch(context, currentAgent);
-    if (topicMismatch) {
-      return topicMismatch;
-    }
-
-    // Performance-based handoff
-    if (context.agentPerformance < 0.4 && context.conversationDepth > 3) {
-      return {
-        type: 'performance_decline',
-        confidence: 0.7,
-        targetAgent: this.suggestBetterAgent(context, currentAgent),
-        reason: 'Current agent performance declining, suggesting alternative',
-      };
-    }
-
-    // Conversation stagnation
-    if (context.conversationDepth > 8 && context.userSatisfaction < 0.6) {
-      return {
-        type: 'conversation_stagnation',
-        confidence: 0.6,
-        targetAgent: this.suggestRefreshAgent(currentAgent),
-        reason: 'Conversation needs fresh perspective',
-      };
-    }
-
-    return null;
-  }
-
-  // Detect if current topic doesn't match current agent's expertise
-  private detectTopicMismatch(
-    context: ConversationContext,
-    currentAgent: AgentType,
-  ): HandoffTrigger | null {
-    const topicAgentMap: Record<string, AgentType> = {
-      technical: 'website_support',
-      humor: 'joke',
-      educational: 'trivia',
-      visual_entertainment: 'gif',
-    };
-
-    const idealAgent = topicAgentMap[context.conversationTopic];
-    if (
-      idealAgent &&
-      idealAgent !== currentAgent &&
-      context.conversationDepth > 2
-    ) {
-      return {
-        type: 'expertise_mismatch',
-        confidence: 0.8,
-        targetAgent: idealAgent,
-        reason: `Topic '${context.conversationTopic}' better handled by ${idealAgent} agent`,
-      };
-    }
-
-    return null;
-  }
-
-  // Suggest a better agent based on context
-  private suggestBetterAgent(
-    context: ConversationContext,
-    currentAgent: AgentType,
-  ): AgentType {
-    // Based on conversation topic
-    if (context.conversationTopic === 'technical') {
-      return 'website_support';
-    }
-    if (context.conversationTopic === 'humor') {
-      return 'joke';
-    }
-    if (context.conversationTopic === 'educational') {
-      return 'trivia';
-    }
-    if (context.conversationTopic === 'visual_entertainment') {
-      return 'gif';
-    }
-
-    // Default fallback to general agent if current agent isn't performing well
-    return currentAgent === 'general' ? 'joke' : 'general';
-  }
-
-  // Suggest a different agent to refresh conversation
-  private suggestRefreshAgent(currentAgent: AgentType): AgentType {
-    const refreshOptions: Record<AgentType, AgentType> = {
-      general: 'joke',
-      joke: 'trivia',
-      trivia: 'gif',
-      gif: 'riddle_master',
-      account_support: 'hold_agent',
-      billing_support: 'hold_agent',
-      website_support: 'hold_agent',
-      operator_support: 'hold_agent',
-      hold_agent: 'joke',
-      story_teller: 'riddle_master',
-      riddle_master: 'quote_master',
-      quote_master: 'game_host',
-      game_host: 'music_guru',
-      music_guru: 'youtube_guru',
-      youtube_guru: 'story_teller',
-      dnd_master: 'story_teller',
-    };
-
-    return refreshOptions[currentAgent] || 'hold_agent';
-  }
-
-  // Generate handoff message for smooth transition
-  generateHandoffMessage(context: ConversationContext): string | null {
-    if (!context.shouldHandoff || !context.handoffTarget) {
-      return null;
-    }
-
-    const handoffMessages: Record<string, Record<AgentType, string>> = {
-      explicit_request: {
-        website_support:
-          "I can see you're having technical or website issues! Let me connect you with our Website Issues Specialist who can help with browser and functionality problems.",
-        joke: "I can tell you're looking for some laughs! Let me bring in our Adaptive Joke Master - they learn your sense of humor and get better at making you laugh over time.",
-        trivia:
-          "You're curious about fascinating facts! Our Trivia Master has an amazing collection of knowledge to share with you.",
-        gif: 'For visual entertainment and fun GIFs, our GIF Master is perfect for that!',
-        general:
-          'Let me connect you with our General Assistant who can help with a wide range of topics.',
-        account_support:
-          'I can see you have an account-related question! Let me connect you with our Account Support Specialist who handles login, profile, and security issues.',
-        billing_support:
-          'This looks like a billing or payment question! Our Billing Support Specialist is the expert for subscription, payment, and refund matters.',
-        operator_support:
-          'Let me connect you with our Customer Service Operator who can coordinate multiple departments and handle complex issues.',
-        hold_agent:
-          'Let me connect you with our Hold Agent who will keep you updated on wait times and coordinate entertainment while you wait for specialist assistance.',
-        story_teller:
-          'Let me bring in our Story Teller who can craft engaging short stories to entertain you!',
-        riddle_master:
-          'Our Riddle Master has fascinating brain teasers and puzzles to challenge your mind!',
-        quote_master:
-          'Our Quote Master has inspirational and entertaining quotes to share with you!',
-        game_host:
-          'Let me connect you with our Game Host who can start fun interactive games to pass the time!',
-        music_guru:
-          'Our Music Guru can provide personalized music recommendations and discuss your favorite artists!',
-        youtube_guru:
-          'Let me bring in our YouTube Guru who has amazing funny videos and viral content to entertain you!',
-        dnd_master:
-          'Let me bring in our D&D Master who can run an interactive RPG lite experience with dice rolling, character creation, and random encounters!',
-      },
-      expertise_mismatch: {
-        joke: 'I think our Adaptive Joke Master would be perfect for bringing some humor to this conversation!',
-        trivia:
-          'Our Trivia Master would love to share some fascinating knowledge with you about this topic!',
-        gif: 'Let me bring in our GIF Master to add some visual fun to this conversation!',
-        general:
-          'Our General Assistant might have a fresh perspective on this topic.',
-        account_support:
-          'This appears to be account-related. Our Account Support Specialist would be better equipped to handle this securely and efficiently.',
-        billing_support:
-          'This sounds like a billing matter. Our Billing Support Specialist has the expertise and access needed for financial inquiries.',
-        website_support:
-          'This seems to be a website functionality issue. Our Website Issues Specialist can provide targeted technical troubleshooting.',
-        operator_support:
-          "This looks like a complex issue that would benefit from our Customer Service Operator's coordination expertise.",
-        hold_agent:
-          'Let me connect you with our Hold Agent who specializes in managing wait times and coordinating appropriate entertainment while you wait.',
-        story_teller:
-          'This seems perfect for our Story Teller who can craft engaging narratives on this topic!',
-        riddle_master:
-          'Our Riddle Master would love to create mind-bending puzzles around this theme!',
-        quote_master:
-          'Our Quote Master has relevant wisdom and quotes that would perfectly address this topic!',
-        game_host:
-          'Our Game Host could turn this into an interactive and engaging experience!',
-        music_guru:
-          'Our Music Guru has perfect musical knowledge and recommendations for this topic!',
-        youtube_guru:
-          'Our YouTube Guru has amazing funny videos and viral content perfect for this topic!',
-        dnd_master:
-          'Our D&D Master would be perfect for turning this topic into an interactive RPG adventure with dice, characters, and storytelling!',
-      },
-      performance_decline: {
-        joke: 'How about we lighten the mood? Our Adaptive Joke Master is great at turning things around with some personalized humor!',
-        trivia:
-          'Maybe our Trivia Master can share something interesting that might be more helpful?',
-        gif: "Let's try something different! Our GIF Master can add some visual entertainment to brighten things up.",
-        general:
-          'Let me bring in our General Assistant for a fresh approach to your question.',
-        account_support:
-          'Let me connect you with our Account Support Specialist who might have better solutions for your account concerns.',
-        billing_support:
-          'Our Billing Support Specialist might be able to provide better assistance with your financial inquiry.',
-        website_support:
-          'Let me bring in our Website Issues Specialist who might have different troubleshooting approaches for your technical issue.',
-        operator_support:
-          'Our Customer Service Operator might be able to coordinate a better solution for your complex inquiry.',
-        hold_agent:
-          'Let me connect you with our Hold Agent who can provide better hold management and entertainment coordination while you wait.',
-        story_teller:
-          'How about a fresh story approach? Our Story Teller might have exactly what you need!',
-        riddle_master:
-          "Let's try some brain teasers! Our Riddle Master could help engage your mind differently!",
-        quote_master:
-          'Our Quote Master might have the perfect inspirational words to help!',
-        game_host:
-          "Let's make this more interactive! Our Game Host can turn this into an engaging experience!",
-        music_guru:
-          'Our Music Guru might have the perfect musical perspective to help brighten things up!',
-        youtube_guru:
-          "Let's try our YouTube Guru - they have amazing funny videos that might be exactly what you need!",
-        dnd_master:
-          'How about we try something completely different? Our D&D Master can create an immersive RPG experience with dice rolling and adventures that might be exactly what you need!',
-      },
-      conversation_stagnation: {
-        joke: 'How about we shake things up with some humor? Our Adaptive Joke Master is great at refreshing conversations!',
-        trivia:
-          'Maybe our Trivia Master can share something fascinating to spark new ideas?',
-        gif: "Let's add some visual fun! Our GIF Master can definitely liven up our conversation.",
-        general:
-          'Our General Assistant might bring a fresh perspective to keep our conversation engaging.',
-        account_support:
-          'Let me bring in our Account Support Specialist for a fresh approach to your account-related concerns.',
-        billing_support:
-          'Our Billing Support Specialist might have different options to explore for your billing inquiry.',
-        website_support:
-          "Let's try our Website Issues Specialist - they might have alternative solutions for your technical problem.",
-        operator_support:
-          'Our Customer Service Operator can bring fresh coordination and multiple-department expertise to help resolve this.',
-        hold_agent:
-          'Let me connect you with our Hold Agent who can provide fresh updates on your wait status and coordinate different entertainment options.',
-        story_teller:
-          "Let's shake things up with some storytelling! Our Story Teller can bring fresh narrative energy to our conversation!",
-        riddle_master:
-          'How about we challenge your mind differently? Our Riddle Master has fresh puzzles to reinvigorate our chat!',
-        quote_master:
-          'Our Quote Master has inspiring words that might spark new directions for our conversation!',
-        game_host:
-          "Let's try something completely different! Our Game Host can bring interactive fun to refresh our discussion!",
-        music_guru:
-          'Our Music Guru can bring a whole new vibe with music recommendations and discussions to liven things up!',
-        youtube_guru:
-          "Let's try our YouTube Guru! They have incredible funny videos and viral content that can completely transform our conversation energy!",
-        dnd_master:
-          "Let's completely reinvent our conversation! Our D&D Master can transform this into an epic interactive RPG adventure with dice rolling, character creation, and immersive storytelling!",
-      },
-    };
-
-    const reasonCategory = context.handoffReason?.includes('explicit')
-      ? 'explicit_request'
-      : context.handoffReason?.includes('expertise')
-        ? 'expertise_mismatch'
-        : context.handoffReason?.includes('performance')
-          ? 'performance_decline'
-          : 'conversation_stagnation';
-
-    return (
-      handoffMessages[reasonCategory]?.[context.handoffTarget] ||
-      `Let me connect you with a different assistant who might be better suited to help you.`
-    );
-  }
-
   // Complete the handoff and reset context
   completeHandoff(userId: string, newAgent: AgentType): ConversationContext {
     const context = this.contexts.get(userId);
@@ -544,11 +161,8 @@ export class ConversationManager {
       return this.initializeContext(userId, newAgent);
     }
 
-    // Reset handoff flags and update agent
+    // Update agent and reset per-agent metrics
     context.currentAgent = newAgent;
-    context.shouldHandoff = false;
-    context.handoffReason = undefined;
-    context.handoffTarget = undefined;
     context.conversationDepth = 0; // Reset depth for new agent
     context.agentPerformance = 0.7; // Reset performance for new agent
 
@@ -559,29 +173,6 @@ export class ConversationManager {
   // Get current context for a user
   getContext(userId: string): ConversationContext | null {
     return this.contexts.get(userId) || null;
-  }
-
-  // Check if handoff is needed
-  shouldHandoff(userId: string): boolean {
-    const context = this.contexts.get(userId);
-    return context?.shouldHandoff || false;
-  }
-
-  // Get handoff information
-  getHandoffInfo(
-    userId: string,
-  ): { target: AgentType; reason: string; message: string } | null {
-    const context = this.contexts.get(userId);
-    if (!context?.shouldHandoff || !context.handoffTarget) {
-      return null;
-    }
-
-    return {
-      target: context.handoffTarget,
-      reason: context.handoffReason || 'Unknown reason',
-      message:
-        this.generateHandoffMessage(context) || 'Switching to better agent',
-    };
   }
 
   // Clean up old contexts

--- a/backend/src/agents/router.ts
+++ b/backend/src/agents/router.ts
@@ -1,0 +1,369 @@
+import { AgentType } from './types';
+import { Message } from '../types';
+import { classifyMessage } from './classifier';
+import { addSpanEvent } from '../tracing/tracer';
+import type { Span } from '@opentelemetry/api';
+
+/**
+ * Pre-dispatch routing decision.
+ *
+ * This is produced by `routeMessage` BEFORE any agent is invoked, so the
+ * correct agent handles the current turn even when the user's request does
+ * not match the previously-selected agent. This fixes the classic
+ * "handoff is one turn late" bug.
+ */
+export interface RoutingDecision {
+  selectedAgent: AgentType;
+  handoff: boolean;
+  confidence: number;
+  reason: string;
+  source: 'keyword' | 'classifier' | 'sticky';
+}
+
+/**
+ * Keyword tables per agent type. Ordering inside each list is irrelevant —
+ * the tie-break priority below decides ordering between agents.
+ *
+ * Only include keywords that are strong, unambiguous intent signals. When in
+ * doubt, defer to the classifier.
+ */
+const KEYWORDS: Record<string, string[]> = {
+  youtube_guru: [
+    'youtube',
+    'youtube video',
+    'yt video',
+    'video',
+    'viral video',
+    'viral',
+    'watch a video',
+    'show me a video',
+    'funny video',
+    'entertaining video',
+    'show me something funny',
+  ],
+  joke: [
+    'joke',
+    'jokes',
+    'tell me a joke',
+    'dad joke',
+    'dad jokes',
+    'pun',
+    'puns',
+    'make me laugh',
+    'funny',
+    'cheesy joke',
+    'one-liner',
+    'wordplay',
+    'punchline',
+  ],
+  gif: [
+    'gif',
+    'gifs',
+    'meme',
+    'memes',
+    'reaction gif',
+    'animated image',
+    'giphy',
+    'tenor',
+    'reaction image',
+  ],
+  trivia: [
+    'trivia',
+    'fun fact',
+    'fun facts',
+    'random fact',
+    'random facts',
+    'did you know',
+    'tell me a fact',
+    'share a fact',
+    'interesting fact',
+    'fascinating fact',
+    'historical fact',
+    'scientific fact',
+  ],
+  dnd_master: [
+    'd&d',
+    'dnd',
+    'dungeons and dragons',
+    'dungeon master',
+    'rpg',
+    'roll dice',
+    'roll a d20',
+    'roll a d6',
+    'roll a d4',
+    'roll a d8',
+    'roll a d10',
+    'roll a d12',
+    'roll a d100',
+    'dice roll',
+    'character sheet',
+    'adventure hook',
+  ],
+  story_teller: [
+    'tell me a story',
+    'story time',
+    'short story',
+    'bedtime story',
+    'write a story',
+    'tell a story',
+  ],
+  riddle_master: [
+    'riddle',
+    'riddles',
+    'brain teaser',
+    'brain teasers',
+    'puzzle me',
+    'give me a riddle',
+  ],
+  quote_master: [
+    'quote',
+    'quotes',
+    'inspirational quote',
+    'famous quote',
+    'motivational quote',
+    'share a quote',
+  ],
+  music_guru: [
+    'music recommendation',
+    'recommend music',
+    'recommend a song',
+    'song recommendation',
+    'music suggestion',
+    'playlist',
+    'favorite artist',
+    'band recommendation',
+  ],
+  account_support: [
+    'login',
+    'log in',
+    'cannot log in',
+    "can't log in",
+    'password reset',
+    'forgot my password',
+    'account locked',
+    'account security',
+    'profile settings',
+    'account support',
+    'two-factor',
+    '2fa',
+  ],
+  billing_support: [
+    'billing',
+    'invoice',
+    'refund',
+    'payment failed',
+    'cancel subscription',
+    'subscription',
+    'pricing',
+    'charge on my card',
+    'credit card',
+    'payment method',
+    'billing issue',
+  ],
+  website_support: [
+    'website broken',
+    "website isn't working",
+    "website won't load",
+    'page not loading',
+    '500 error',
+    '404 error',
+    'browser issue',
+    'debug this code',
+    'fix this code',
+    'syntax error',
+    'runtime error',
+    'javascript error',
+    'typescript error',
+    'react component',
+    'css bug',
+    'html bug',
+  ],
+};
+
+/**
+ * Tie-break priority when multiple agents match keyword-wise. Agents earlier
+ * in the list win. Rationale:
+ *   - youtube_guru, joke, gif, trivia, dnd_master are very frequent user
+ *     intents and map to dedicated entertainment agents, so we route there
+ *     before falling back to more general specialists.
+ *   - account/billing/website support come last; they are usually expressed
+ *     with unambiguous phrases so keyword collision is unlikely.
+ */
+const PRIORITY: AgentType[] = [
+  'youtube_guru',
+  'joke',
+  'gif',
+  'trivia',
+  'dnd_master',
+  'story_teller',
+  'riddle_master',
+  'music_guru',
+  'quote_master',
+  'account_support',
+  'billing_support',
+  'website_support',
+];
+
+function matchKeywords(lower: string): {
+  agent: AgentType;
+  matches: number;
+} | null {
+  const scores = new Map<AgentType, number>();
+
+  for (const agent of PRIORITY) {
+    const list = KEYWORDS[agent];
+    if (!list) {
+      continue;
+    }
+    let score = 0;
+    for (const kw of list) {
+      if (lower.includes(kw)) {
+        score++;
+      }
+    }
+    if (score > 0) {
+      scores.set(agent, score);
+    }
+  }
+
+  if (scores.size === 0) {
+    return null;
+  }
+
+  // Priority order wins on ties; earlier in PRIORITY beats later regardless
+  // of raw match count (we want youtube to beat trivia when both match,
+  // even if trivia matched two keywords).
+  for (const agent of PRIORITY) {
+    const s = scores.get(agent);
+    if (s !== undefined) {
+      return { agent, matches: s };
+    }
+  }
+  return null;
+}
+
+/**
+ * Route an incoming user message to the correct agent BEFORE dispatch.
+ *
+ * Logic (first match wins):
+ *   Step A — Explicit keyword intent.  If the message contains strong
+ *            signals for a particular specialist, route there immediately.
+ *   Step B — LLM intent classification.  If the classifier returns a
+ *            non-`general` agent with reasonable confidence, trust it.
+ *   Step C — Sticky default.  Otherwise keep the current agent.
+ *
+ * @param userMessage   The user's latest message text.
+ * @param currentAgent  The agent currently owning the conversation.
+ * @param _history      Conversation history (reserved for future scoring).
+ */
+export async function routeMessage(
+  userMessage: string,
+  currentAgent: AgentType,
+  _history: Message[] = [],
+): Promise<RoutingDecision> {
+  const trimmed = (userMessage || '').trim();
+  const lower = trimmed.toLowerCase();
+
+  // Step A: explicit keyword intent
+  const kw = matchKeywords(lower);
+  if (kw) {
+    return {
+      selectedAgent: kw.agent,
+      handoff: kw.agent !== currentAgent,
+      confidence: Math.min(0.99, 0.8 + kw.matches * 0.05),
+      reason: `keyword intent match: ${kw.agent} (${kw.matches} keyword${
+        kw.matches === 1 ? '' : 's'
+      })`,
+      source: 'keyword',
+    };
+  }
+
+  // Step B: classifier
+  if (trimmed.length > 0) {
+    try {
+      const classification = await classifyMessage(trimmed);
+      if (
+        classification.agentType &&
+        classification.agentType !== 'general' &&
+        classification.confidence >= 0.6
+      ) {
+        return {
+          selectedAgent: classification.agentType,
+          handoff: classification.agentType !== currentAgent,
+          confidence: classification.confidence,
+          reason: `classifier: ${classification.reasoning}`,
+          source: 'classifier',
+        };
+      }
+    } catch (err) {
+      // Swallow — fall through to sticky default.
+      console.warn('routeMessage classifier failed:', err);
+    }
+  }
+
+  // Step C: sticky default
+  return {
+    selectedAgent: currentAgent,
+    handoff: false,
+    confidence: 0.5,
+    reason: 'no strong intent signal; staying with current agent',
+    source: 'sticky',
+  };
+}
+
+/**
+ * Emit a routing decision as a tracing event and a structured console log.
+ *
+ * Keeping this in a single helper means every call site logs the same shape,
+ * which makes post-hoc debugging of mis-routes much easier.
+ */
+export function logRoutingDecision(
+  decision: RoutingDecision,
+  ctx: {
+    userId?: string;
+    conversationId?: string;
+    currentAgent: AgentType;
+    messagePreview?: string;
+  },
+  span?: Span,
+): void {
+  const payload = {
+    userId: ctx.userId,
+    conversationId: ctx.conversationId,
+    fromAgent: ctx.currentAgent,
+    toAgent: decision.selectedAgent,
+    handoff: decision.handoff,
+    confidence: decision.confidence,
+    reason: decision.reason,
+    source: decision.source,
+    messagePreview: ctx.messagePreview,
+  };
+
+  if (decision.handoff) {
+    console.log(
+      `🧭 ROUTER handoff ${ctx.currentAgent} → ${decision.selectedAgent} [${decision.source}] (conf=${decision.confidence.toFixed(2)}): ${decision.reason}`,
+    );
+  } else {
+    console.log(
+      `🧭 ROUTER stick with ${decision.selectedAgent} [${decision.source}] (conf=${decision.confidence.toFixed(2)}): ${decision.reason}`,
+    );
+  }
+
+  if (span) {
+    addSpanEvent(span, 'router.decision', {
+      'router.from_agent': ctx.currentAgent,
+      'router.to_agent': decision.selectedAgent,
+      'router.handoff': decision.handoff,
+      'router.confidence': decision.confidence,
+      'router.source': decision.source,
+      'router.reason': decision.reason.substring(0, 200),
+    });
+  }
+
+  // Also emit a single-line JSON log for structured ingestion.
+  try {
+    console.log(`ROUTER_DECISION ${JSON.stringify(payload)}`);
+  } catch {
+    // ignore serialization issues
+  }
+}

--- a/backend/src/socket/socketHandlers.ts
+++ b/backend/src/socket/socketHandlers.ts
@@ -51,17 +51,18 @@ const executeProactiveAction = async (
     );
 
     // Validate the proactive response
-    const validationResult =
-      await import('../validation/responseValidator').then(module =>
-        module.responseValidator.validateResponse(
-          proactiveResponse.agentUsed,
-          action.message,
-          proactiveResponse.content,
-          conversation.id,
-          socket.id,
-          true, // This is a proactive message
-        ),
-      );
+    const validationResult = await import(
+      '../validation/responseValidator'
+    ).then(module =>
+      module.responseValidator.validateResponse(
+        proactiveResponse.agentUsed,
+        action.message,
+        proactiveResponse.content,
+        conversation.id,
+        socket.id,
+        true, // This is a proactive message
+      ),
+    );
 
     // Log validation for proactive messages
     if (validationResult.issues.length > 0) {
@@ -370,21 +371,23 @@ export const setupSocketHandlers = (
           );
         }
 
-        // If user has been idle for more than 5 minutes with hold agent, suggest entertainment
+        // If user has been idle for more than 5 minutes with hold agent,
+        // force a handoff to a default entertainment agent. Router-based
+        // handoff is driven by the user's next message, but on long idle
+        // periods we want to be proactive so we force it directly.
         if (
           timeSinceLastMessage > 300000 &&
           conversationContext.currentAgent === 'hold_agent'
         ) {
           // 5 minutes
-          if (!conversationContext.shouldHandoff) {
-            conversationContext.shouldHandoff = true;
-            conversationContext.handoffTarget = 'joke'; // Default entertainment
-            conversationContext.handoffReason =
-              'Extended idle time - offering entertainment while waiting';
-            console.log(
-              `🕐 Auto-triggering entertainment handoff for idle user ${socket.id} after 5 minutes`,
-            );
-          }
+          console.log(
+            `🕐 Auto-triggering entertainment handoff for idle user ${socket.id} after 5 minutes`,
+          );
+          agentService.forceAgentHandoff(
+            socket.id,
+            'joke',
+            'Extended idle time - offering entertainment while waiting',
+          );
         }
       }
 
@@ -443,9 +446,6 @@ export const setupSocketHandlers = (
               conversationDepth: conversationContext.conversationDepth,
               userSatisfaction: conversationContext.userSatisfaction,
               agentPerformance: conversationContext.agentPerformance,
-              shouldHandoff: conversationContext.shouldHandoff,
-              handoffTarget: conversationContext.handoffTarget,
-              handoffReason: conversationContext.handoffReason,
               timeSinceLastMessage:
                 Date.now() - conversationContext.lastMessageTime.getTime(),
               idleTime: Math.floor(
@@ -930,9 +930,9 @@ export const setupSocketHandlers = (
                 `💬 Conversation context - Agent: ${ctx.currentAgent}, Topic: ${ctx.conversationTopic}, Depth: ${ctx.conversationDepth}, Satisfaction: ${ctx.userSatisfaction.toFixed(2)}, Performance: ${ctx.agentPerformance.toFixed(2)}`,
               );
 
-              if (ctx.shouldHandoff) {
+              if (agentResponse.handoffInfo) {
                 console.log(
-                  `🔄 Handoff needed: ${ctx.currentAgent} → ${ctx.handoffTarget} (${ctx.handoffReason})`,
+                  `🔄 Pre-dispatch handoff applied: → ${agentResponse.handoffInfo.target} (${agentResponse.handoffInfo.reason})`,
                 );
               }
             }


### PR DESCRIPTION
## Summary

Fixes a timing bug in multi-agent handoffs where specialist agents answered messages that belonged to a different agent. When the joke agent owned the conversation and the user said "show me a youtube video", joke responded with a joke before the system recognized the domain mismatch — the handoff to `youtube_guru` only fired on the next turn.

Root cause in `agentService.processMessageWithConversation`: the current agent produced the response BEFORE `detectHandoffTriggers` ran, so the handoff was always one turn late.

## What changed

- **New `backend/src/agents/router.ts`** — pre-dispatch routing gate. Given the user message, current agent, and history, it returns a `RoutingDecision { selectedAgent, handoff, confidence, reason, source }`. Logic (first match wins): explicit keyword intent → LLM classifier → sticky default.
- **`agentService.processMessageWithConversation`** — now calls `routeMessage` first, completes the handoff synchronously via `completeHandoff`, then dispatches with the routed agent. Preserves the existing hold_agent → random-entertainment-agent auto-handoff on the first message.
- **`conversationManager`** — `detectHandoffTriggers`, `detectTopicMismatch`, `suggestBetterAgent`, `suggestRefreshAgent`, `generateHandoffMessage`, `getHandoffInfo`, `shouldHandoff` removed. `ConversationContext` loses `shouldHandoff/handoffTarget/handoffReason` — handoff state is computed per-turn in the router now, not stored.
- **`agentService.forceAgentHandoff`** — now calls `completeHandoff` directly (synchronous), not a queued next-turn trigger.
- **`socketHandlers`** — 5-min idle hold→joke block uses `forceAgentHandoff`. Agent-status payload no longer exposes removed handoff fields.
- **Agent prompts (`config.ts`)** — SCOPE & DEFERRAL block added to 9 entertainment agents (joke, trivia, gif, story_teller, riddle_master, quote_master, music_guru, youtube_guru, dnd_master) as defense-in-depth if the router misclassifies.
- **Tests** — new `router.test.ts` (12 unit cases), new `handoff.integration.test.ts` (incl. the joke→youtube regression), updated `agentService.test.ts` for synchronous handoff semantics.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test -- --runInBand` — 400/400 passing (including new router unit + joke→youtube integration regression)
- [ ] Manual smoke: seed joke agent → ask "show me a youtube video" → verify `agentUsed === 'youtube_guru'` on the SAME turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)