### PR TITLE
feat(ui): emit handoff_event and render transfer chip

### DIFF
--- a/backend/src/socket/__tests__/socketHandlers.test.ts
+++ b/backend/src/socket/__tests__/socketHandlers.test.ts
@@ -533,6 +533,44 @@ describe('Socket Handlers', () => {
       );
     });
 
+    it('should emit handoff_event when the router selects a new agent', async () => {
+      (agentService.getCurrentAgent as jest.Mock).mockReturnValueOnce('joke');
+      (
+        agentService.processMessageWithBothSystems as jest.Mock
+      ).mockResolvedValue({
+        content: 'Here is a video',
+        agentUsed: 'youtube_guru',
+        confidence: 0.95,
+        proactiveActions: [],
+        handoffInfo: {
+          target: 'youtube_guru',
+          reason: 'Detected youtube_guru keywords',
+          message: 'Connecting you to our YouTube Guru.',
+        },
+      });
+
+      await withTimeout(streamChatHandler({ message: 'show me a video' }));
+
+      expect(mockIo.emit).toHaveBeenCalledWith(
+        'handoff_event',
+        expect.objectContaining({
+          fromAgent: 'joke',
+          toAgent: 'youtube_guru',
+          message: 'Connecting you to our YouTube Guru.',
+          reason: 'Detected youtube_guru keywords',
+        }),
+      );
+    });
+
+    it('should NOT emit handoff_event when no handoff occurs', async () => {
+      await withTimeout(streamChatHandler({ message: 'test message' }));
+
+      const handoffCalls = (mockIo.emit as jest.Mock).mock.calls.filter(
+        call => call[0] === 'handoff_event',
+      );
+      expect(handoffCalls).toHaveLength(0);
+    });
+
     it('should handle agent service errors', async () => {
       const data = { message: 'test message' };
       (

--- a/backend/src/socket/socketHandlers.ts
+++ b/backend/src/socket/socketHandlers.ts
@@ -879,6 +879,10 @@ export const setupSocketHandlers = (
               '🤖 Processing message with conversation management and goal-seeking systems...',
             );
 
+            // Capture current agent BEFORE dispatch so we can report the
+            // from→to transition in the handoff_event socket emission.
+            const previousAgent = agentService.getCurrentAgent(socket.id);
+
             // Track chat message and agent response time
             const responseStart = Date.now();
             metrics.chatMessagesTotal.inc({
@@ -935,6 +939,20 @@ export const setupSocketHandlers = (
                   `🔄 Pre-dispatch handoff applied: → ${agentResponse.handoffInfo.target} (${agentResponse.handoffInfo.reason})`,
                 );
               }
+            }
+
+            // Notify clients of a pre-dispatch handoff so the UI can show a
+            // transient "Transferring you to <Agent>" chip before the stream
+            // starts. Emitted only when the router picked a new agent.
+            if (agentResponse.handoffInfo) {
+              io.to(conversation.id).emit('handoff_event', {
+                conversationId: conversation.id,
+                messageId: aiMessageId,
+                fromAgent: previousAgent,
+                toAgent: agentResponse.handoffInfo.target,
+                message: agentResponse.handoffInfo.message,
+                reason: agentResponse.handoffInfo.reason,
+              });
             }
 
             // Simulate streaming by sending the response in chunks

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -11,6 +11,7 @@ import { socketService } from '../../services/socketService';
 import ChatScreen from '../../components/ChatScreen';
 import MessageInput from '../../components/MessageInput';
 import { UserProfile } from '../../components/UserProfile';
+import { HandoffChip } from '../../components/HandoffChip';
 import type { Conversation, Message } from '../../types';
 
 export default function HomeScreen() {
@@ -18,6 +19,7 @@ export default function HomeScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [handoffMessage, setHandoffMessage] = useState<string | null>(null);
 
   // Initialize socket connection on app start
   useEffect(() => {
@@ -233,6 +235,8 @@ export default function HomeScreen() {
       agentUsed?: string;
       confidence?: number;
     }) => {
+      // Dismiss any active handoff chip once the new agent has responded.
+      setHandoffMessage(null);
       // Update message with final agent info and complete status
       setConversation(prev => {
         if (!prev) return data.conversation;
@@ -299,12 +303,24 @@ export default function HomeScreen() {
       });
     };
 
+    const handleHandoffEvent = (event: {
+      conversationId: string;
+      messageId: string;
+      fromAgent: string;
+      toAgent: string;
+      message: string;
+      reason: string;
+    }) => {
+      setHandoffMessage(event.message);
+    };
+
     // Set up socket listeners
     socketService.onNewMessage(handleNewMessage);
     socketService.onStreamStart(handleStreamStart);
     socketService.onStreamChunk(handleStreamChunk);
     socketService.onStreamComplete(handleStreamComplete);
     socketService.onProactiveMessage(handleProactiveMessage);
+    socketService.onHandoffEvent(handleHandoffEvent);
 
     return () => {
       socketService.removeListener('new_message');
@@ -312,6 +328,7 @@ export default function HomeScreen() {
       socketService.removeListener('stream_chunk');
       socketService.removeListener('stream_complete');
       socketService.removeListener('proactive_message');
+      socketService.removeListener('handoff_event');
     };
   }, []);
 
@@ -369,6 +386,7 @@ export default function HomeScreen() {
   return (
     <View style={styles.container}>
       <UserProfile />
+      {handoffMessage && <HandoffChip message={handoffMessage} />}
       {/* Chat Area with Combined Menu/Status Bar */}
       <View style={styles.chatContainer}>
         <ChatScreen conversation={conversation} />

--- a/frontend/components/HandoffChip.tsx
+++ b/frontend/components/HandoffChip.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { DiscordColors } from '../constants/Colors';
+
+interface HandoffChipProps {
+  message: string;
+}
+
+export function HandoffChip({ message }: HandoffChipProps) {
+  return (
+    <View style={styles.container} accessibilityRole='alert'>
+      <ActivityIndicator size='small' color={DiscordColors.brandPrimary} />
+      <Text style={styles.text} numberOfLines={2}>
+        {message}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 12,
+    marginTop: 8,
+    marginBottom: 4,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 16,
+    backgroundColor: DiscordColors.backgroundSecondary,
+    borderWidth: 1,
+    borderColor: DiscordColors.brandPrimary,
+  },
+  text: {
+    marginLeft: 8,
+    color: DiscordColors.textNormal,
+    fontSize: 13,
+    fontStyle: 'italic',
+    flexShrink: 1,
+  },
+});

--- a/frontend/services/socketService.ts
+++ b/frontend/services/socketService.ts
@@ -25,6 +25,15 @@ type NewMessageCallback = (message: Message) => void;
 type ProactiveMessageCallback = (data: { message: Message }) => void;
 type StreamErrorCallback = (error: { code: string; message: string }) => void;
 type AgentStatusCallback = (status: AgentStatus) => void;
+export type HandoffEvent = {
+  conversationId: string;
+  messageId: string;
+  fromAgent: string;
+  toAgent: string;
+  message: string;
+  reason: string;
+};
+type HandoffEventCallback = (event: HandoffEvent) => void;
 
 class SocketService {
   private socket: Socket | null = null;
@@ -39,6 +48,7 @@ class SocketService {
     proactive_message?: ProactiveMessageCallback;
     stream_error?: StreamErrorCallback;
     agent_status_update?: AgentStatusCallback;
+    handoff_event?: HandoffEventCallback;
   } = {};
 
   // Callbacks for connection events
@@ -379,6 +389,13 @@ class SocketService {
   ): void {
     if (this.socket) {
       this.socket.on('proactive_error', callback);
+    }
+  }
+
+  onHandoffEvent(callback: HandoffEventCallback): void {
+    this.storedCallbacks.handoff_event = callback;
+    if (this.socket) {
+      this.socket.on('handoff_event', callback);
     }
   }
 


### PR DESCRIPTION
## Summary
- Backend emits a `handoff_event` socket message whenever the pre-dispatch router selects a different agent, with `{fromAgent, toAgent, message, reason, conversationId, messageId}`.
- Frontend adds `socketService.onHandoffEvent()` and a small `HandoffChip` that renders a transient "Connecting you to our X." chip above the chat until `stream_complete` fires.
- Completes the optional UI piece from the routing-gate plan (follow-up to #157).

## Test plan
- [x] `backend: npm run lint && npx tsc --noEmit`
- [x] `backend: npx jest src/socket` — 25/25 pass, new cases: emits `handoff_event` on router handoff; no emit when sticky
- [x] `frontend: npx tsc --noEmit`
- [x] `frontend: npx eslint services/socketService.ts components/HandoffChip.tsx app/(tabs)/index.tsx`
- [ ] Manual smoke: say "tell me a joke" → joke; then "show me a youtube video" — chip appears, then YouTube Guru response streams in

🤖 Generated with [Claude Code](https://claude.com/claude-code)