### PR TITLE
feat(llm): route Claude through Azure AI Foundry

### DIFF
--- a/backend/src/llm/anthropicProvider.ts
+++ b/backend/src/llm/anthropicProvider.ts
@@ -44,9 +44,11 @@ interface AnthropicStreamEvent {
 export class AnthropicProvider implements LLMProvider {
   readonly id = 'anthropic' as const;
   private apiKey: string;
+  private baseURL?: string;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, baseURL?: string) {
     this.apiKey = apiKey;
+    this.baseURL = baseURL;
   }
 
   private toAnthropicTools(tools: LLMTool[]): AnthropicTool[] {
@@ -60,7 +62,13 @@ export class AnthropicProvider implements LLMProvider {
   async *stream(opts: LLMStreamOptions): AsyncIterable<LLMStreamEvent> {
     // Lazy import to avoid crash when ANTHROPIC_API_KEY is absent at module load
     const { default: Anthropic } = await import('@anthropic-ai/sdk');
-    const client = new Anthropic({ apiKey: this.apiKey });
+    // baseURL override allows pointing at Azure AI Foundry's Anthropic-compatible endpoint
+    // (e.g. https://{account}.services.ai.azure.com — Foundry exposes Claude via /v1/messages)
+    const client = new Anthropic(
+      this.baseURL
+        ? { apiKey: this.apiKey, baseURL: this.baseURL }
+        : { apiKey: this.apiKey },
+    );
 
     const systemContent = opts.cacheSystem
       ? [

--- a/backend/src/llm/index.ts
+++ b/backend/src/llm/index.ts
@@ -16,8 +16,21 @@ class ProviderRegistry {
     if (process.env.OPENAI_API_KEY) {
       this.openai = new OpenAIProvider(process.env.OPENAI_API_KEY);
     }
+    // Anthropic direct API takes precedence; falls back to Foundry-hosted Claude
+    // when only Foundry is configured (Foundry exposes Anthropic-compatible /v1/messages).
     if (process.env.ANTHROPIC_API_KEY) {
       this.anthropic = new AnthropicProvider(process.env.ANTHROPIC_API_KEY);
+    } else if (
+      process.env.AZURE_FOUNDRY_API_KEY &&
+      process.env.AZURE_FOUNDRY_ENDPOINT
+    ) {
+      this.anthropic = new AnthropicProvider(
+        process.env.AZURE_FOUNDRY_API_KEY,
+        process.env.AZURE_FOUNDRY_ENDPOINT,
+      );
+      logger.info(
+        '[llm] anthropic provider routed through Azure Foundry endpoint',
+      );
     }
     if (process.env.AZURE_FOUNDRY_PROJECT_ENDPOINT) {
       this.foundry = new FoundryProvider(

--- a/k8s/apps/chat/deployment.yaml
+++ b/k8s/apps/chat/deployment.yaml
@@ -60,6 +60,20 @@ spec:
                 secretKeyRef:
                   name: chat-secrets-from-keyvault
                   key: OPENAI_API_KEY
+            # Foundry-hosted Claude (no direct ANTHROPIC_API_KEY in cluster).
+            # When AZURE_FOUNDRY_API_KEY+AZURE_FOUNDRY_ENDPOINT are set and
+            # ANTHROPIC_API_KEY is unset, AnthropicProvider routes /v1/messages
+            # through the Foundry endpoint using @anthropic-ai/sdk's baseURL override.
+            - name: AZURE_FOUNDRY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: chat-secrets-from-keyvault
+                  key: AZURE_FOUNDRY_API_KEY
+            - name: AZURE_FOUNDRY_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: chat-secrets-from-keyvault
+                  key: AZURE_FOUNDRY_ENDPOINT
           envFrom:
             - configMapRef:
                 name: chat-backend-config

--- a/k8s/apps/chat/secret-provider-class.yaml
+++ b/k8s/apps/chat/secret-provider-class.yaml
@@ -41,6 +41,14 @@ spec:
           objectName: OAUTH2-COOKIE-SECRET
           objectType: secret
           objectVersion: ""
+        - |
+          objectName: AZURE-FOUNDRY-API-KEY
+          objectType: secret
+          objectVersion: ""
+        - |
+          objectName: AZURE-FOUNDRY-ENDPOINT
+          objectType: secret
+          objectVersion: ""
     tenantId: '42ddc44e-97dd-4c3b-bf8a-31c785e24c67'
   secretObjects:
     - secretName: chat-secrets-from-keyvault
@@ -60,6 +68,10 @@ spec:
           key: OAUTH2_CLIENT_SECRET
         - objectName: OAUTH2-COOKIE-SECRET
           key: OAUTH2_COOKIE_SECRET
+        - objectName: AZURE-FOUNDRY-API-KEY
+          key: AZURE_FOUNDRY_API_KEY
+        - objectName: AZURE-FOUNDRY-ENDPOINT
+          key: AZURE_FOUNDRY_ENDPOINT
 ---
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass


### PR DESCRIPTION
## Summary

We don't have a direct Anthropic API key — instead deployed three Claude serverless endpoints in Foundry account \`ai-lintnerian1957ai749798164164\` and routed the existing AnthropicProvider through that endpoint via the SDK's \`baseURL\` option.

**Foundry deployments** (created out-of-band):
- \`claude-sonnet-4-6\` (default — used by dnd_master + story_teller)
- \`claude-haiku-4-5\` (cheap)
- \`claude-opus-4-7\` (premium escalation)

All three are serverless paygo (no idle cost).

## Code changes

- \`AnthropicProvider\` gains optional \`baseURL\` constructor arg passed through to \`@anthropic-ai/sdk\`. Foundry exposes the same \`/v1/messages\` Anthropic surface, so no protocol rewrite needed.
- \`ProviderRegistry\` constructs the anthropic provider from \`AZURE_FOUNDRY_API_KEY\` + \`AZURE_FOUNDRY_ENDPOINT\` when \`ANTHROPIC_API_KEY\` is absent.

## Cluster wiring

- \`secret-provider-class.yaml\` mounts \`AZURE-FOUNDRY-API-KEY\` + \`AZURE-FOUNDRY-ENDPOINT\` from \`ai-chat-kv-1763873634\` (already pushed to KV).
- \`deployment.yaml\` exposes them as env vars on the chat-backend container.

## Fallback

\`OPENAI_API_KEY\` remains the primary cred. Without Anthropic/Foundry, all agents fall back to OpenAI gpt-4o-mini.

## Test plan

- [x] Backend typecheck + lint clean
- [x] 360/360 unit tests pass
- [ ] Smoke test post-deploy: hit \`chat.cat-herding.net\`, ask \"play d&d\" → dnd_master should hit Foundry Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)