### PR TITLE
fix(agents): synthesize intro text when LLM emits only a tool_call

### DIFF
--- a/backend/src/agents/agentService.ts
+++ b/backend/src/agents/agentService.ts
@@ -284,6 +284,26 @@ export class AgentService {
             }
           }
 
+          // If the LLM emitted only tool calls (no text) and tools produced
+          // attachments, synthesize a short intro. Many models emit just a
+          // tool_call and rely on a second turn to write the final text; we
+          // don't round-trip here, so we supply a sensible default keyed off
+          // the first attachment type.
+          if (!accText && attachments.length > 0) {
+            const first = attachments[0];
+            const intros: Record<string, string> = {
+              youtube: "Here's a video for you:",
+              video: "Here's a video for you:",
+              audio: "Here's something to listen to:",
+              gif: "Here's a GIF for you:",
+              image: 'Here you go:',
+              image_gallery: 'Here are some images:',
+              dice: 'Here is your roll:',
+              card: 'Here you go:',
+            };
+            accText = intros[first.type] ?? 'Here you go:';
+          }
+
           responseContent =
             accText ||
             `I apologize, but I encountered an error while processing your request. Please try again.`;

--- a/backend/src/socket/socketHandlers.ts
+++ b/backend/src/socket/socketHandlers.ts
@@ -82,6 +82,9 @@ const executeProactiveAction = async (
       agentUsed: proactiveResponse.agentUsed,
       confidence: proactiveResponse.confidence,
       isProactive: true, // Mark as proactive message
+      ...(proactiveResponse.attachments?.length && {
+        attachments: proactiveResponse.attachments,
+      }),
     };
 
     // Add the proactive message to the conversation


### PR DESCRIPTION
## Observed bug (prod)

Hold Agent handed off to GIF Master proactively. GIF Master's LLM call emitted only a \`tool_call\` (gif_search) and no text. Tool fell back to RAG (no GIPHY_API_KEY) and produced an attachment successfully. But because \`accText\` was empty, \`responseContent\` fell through to the catch-all apology string, which the user saw.

## Fix

When at least one tool ran successfully and produced an attachment but the LLM did not emit any text, synthesize a short intro keyed off the first attachment's type (e.g. \`Here's a video for you:\` / \`Here's a GIF for you:\` / \`Here is your roll:\`). This avoids a second round-trip to the LLM while still giving the user a reasonable sentence next to the attachment.

Also updates \`executeProactiveAction\` in socketHandlers to include \`attachments\` on the emitted \`proactive_message\` so hold-time entertainment renders the RAG-provided card.

## Test plan

- [x] 360/360 backend unit tests pass
- [x] backend typecheck clean
- [ ] prod smoke: trigger hold → GIF Master should show RAG GIF with \"Here's a GIF for you:\" caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)