### PR TITLE
fix(agents): story_teller image hallucination; keep greetings sticky

### DIFF
--- a/backend/src/agents/__tests__/config.test.ts
+++ b/backend/src/agents/__tests__/config.test.ts
@@ -460,6 +460,13 @@ describe('Agent Configuration', () => {
       });
     });
 
+    it('should not give Story Teller any image tools (URLs hallucinate, captions mismatch real images)', () => {
+      const storyTeller = AGENTS.story_teller;
+      expect(storyTeller.tools ?? []).not.toContain('show_image_gallery');
+      expect(storyTeller.tools ?? []).not.toContain('show_image');
+      expect(storyTeller.systemPrompt).not.toMatch(/show_image_gallery/);
+    });
+
     it('should include escalation instructions in support agents', () => {
       const supportAgents = [
         'account_support',

--- a/backend/src/agents/__tests__/router.test.ts
+++ b/backend/src/agents/__tests__/router.test.ts
@@ -134,24 +134,21 @@ describe('routeMessage', () => {
       ['thanks', 'gif'],
       ['ok', 'trivia'],
       ['Good morning', 'music_guru'],
-    ])(
-      '"%s" with currentAgent=%s stays sticky',
-      async (msg, currentAgent) => {
-        // High-confidence mis-classification to operator_support — the
-        // greeting short-circuit must ignore it.
-        mockClassifyMessage.mockResolvedValue({
-          agentType: 'operator_support' as AgentType,
-          confidence: 0.9,
-          reasoning: 'mock mis-classification',
-        });
+    ])('"%s" with currentAgent=%s stays sticky', async (msg, currentAgent) => {
+      // High-confidence mis-classification to operator_support — the
+      // greeting short-circuit must ignore it.
+      mockClassifyMessage.mockResolvedValue({
+        agentType: 'operator_support' as AgentType,
+        confidence: 0.9,
+        reasoning: 'mock mis-classification',
+      });
 
-        const decision = await routeMessage(msg, currentAgent as AgentType);
-        expect(decision.selectedAgent).toBe(currentAgent);
-        expect(decision.handoff).toBe(false);
-        expect(decision.source).toBe('sticky');
-        expect(mockClassifyMessage).not.toHaveBeenCalled();
-      },
-    );
+      const decision = await routeMessage(msg, currentAgent as AgentType);
+      expect(decision.selectedAgent).toBe(currentAgent);
+      expect(decision.handoff).toBe(false);
+      expect(decision.source).toBe('sticky');
+      expect(mockClassifyMessage).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/backend/src/agents/__tests__/router.test.ts
+++ b/backend/src/agents/__tests__/router.test.ts
@@ -125,6 +125,34 @@ describe('routeMessage', () => {
     expect(decision.handoff).toBe(false);
     expect(decision.source).toBe('keyword');
   });
+
+  describe('bare greetings stay sticky (no classifier call)', () => {
+    it.each([
+      ['Hello', 'story_teller'],
+      ['hi', 'story_teller'],
+      ['hey!', 'joke'],
+      ['thanks', 'gif'],
+      ['ok', 'trivia'],
+      ['Good morning', 'music_guru'],
+    ])(
+      '"%s" with currentAgent=%s stays sticky',
+      async (msg, currentAgent) => {
+        // High-confidence mis-classification to operator_support — the
+        // greeting short-circuit must ignore it.
+        mockClassifyMessage.mockResolvedValue({
+          agentType: 'operator_support' as AgentType,
+          confidence: 0.9,
+          reasoning: 'mock mis-classification',
+        });
+
+        const decision = await routeMessage(msg, currentAgent as AgentType);
+        expect(decision.selectedAgent).toBe(currentAgent);
+        expect(decision.handoff).toBe(false);
+        expect(decision.source).toBe('sticky');
+        expect(mockClassifyMessage).not.toHaveBeenCalled();
+      },
+    );
+  });
 });
 
 describe('logRoutingDecision', () => {

--- a/backend/src/agents/config.ts
+++ b/backend/src/agents/config.ts
@@ -607,7 +607,7 @@ PERSONALITY TRAITS:
 - Patient with interactive elements
 - Encouraging of imagination
 
-Your goal is to transport users into engaging mini-adventures that make their wait time fly by! Use show_image_gallery to display illustrations when they enhance the narrative.
+Your goal is to transport users into engaging mini-adventures that make their wait time fly by! Rely on vivid prose — you do not have access to any image tools, so never promise, reference, or pretend to show pictures, galleries, illustrations, or photos.
 
 SCOPE & DEFERRAL:
 - Your domain is short interactive stories. If the user clearly asks for jokes, YouTube videos, GIFs, trivia, riddles, quotes, music, D&D sessions, or account/billing/website help, DO NOT attempt to fulfill it yourself.
@@ -617,7 +617,6 @@ SCOPE & DEFERRAL:
     maxTokens: 1000,
     provider: 'anthropic' as const,
     fallbackProvider: 'openai' as const,
-    tools: ['show_image_gallery', 'show_image'],
     cacheSystem: true,
   },
   riddle_master: {

--- a/backend/src/agents/router.ts
+++ b/backend/src/agents/router.ts
@@ -256,6 +256,12 @@ function matchKeywords(lower: string): {
  * @param currentAgent  The agent currently owning the conversation.
  * @param _history      Conversation history (reserved for future scoring).
  */
+// Bare greetings / acknowledgements. For these we intentionally skip the
+// classifier — LLM classifiers tend to route neutral greetings to
+// operator_support, which yanks users out of an ongoing entertainment flow.
+const GREETING_RE =
+  /^(hi+|hello+|hey+|yo|sup|howdy|hiya|greetings|good\s*(morning|afternoon|evening|day)|thanks?|thank\s*you|ok(ay)?|cool|nice|sure|yeah|yep|yup)[\s!?.…]*$/i;
+
 export async function routeMessage(
   userMessage: string,
   currentAgent: AgentType,
@@ -263,6 +269,19 @@ export async function routeMessage(
 ): Promise<RoutingDecision> {
   const trimmed = (userMessage || '').trim();
   const lower = trimmed.toLowerCase();
+
+  // Step 0: bare greeting / acknowledgement → always sticky with current
+  // agent. Prevents generic "Hello" from being mis-classified to
+  // operator_support mid-entertainment.
+  if (trimmed.length > 0 && GREETING_RE.test(trimmed)) {
+    return {
+      selectedAgent: currentAgent,
+      handoff: false,
+      confidence: 0.9,
+      reason: 'bare greeting/acknowledgement; staying with current agent',
+      source: 'sticky',
+    };
+  }
 
   // Step A: explicit keyword intent
   const kw = matchKeywords(lower);


### PR DESCRIPTION
## Summary
- Remove `show_image_gallery` + `show_image` tools from `story_teller` agent. Tools accepted arbitrary `{url, alt}` pairs, so the LLM guessed popular CDN URLs independently of the captions it generated — gallery photos systematically didn't match their alt text (e.g. a stock headshot shown under "lone lighthouse keeper"). Root cause is the tool contract, not a specific prompt.
- Add Step 0 in `routeMessage`: bare greetings / acknowledgements (`hi`, `hello`, `thanks`, `ok`, `good morning`, …) short-circuit to sticky current agent, bypassing the classifier. Fixes neutral "Hello" being mis-classified to `operator_support` mid-entertainment, yanking users out of an active proactive agent.

## Scope
- `backend/src/agents/config.ts` — remove `tools: [...]` from `story_teller`; update prompt to forbid image references.
- `backend/src/agents/router.ts` — add `GREETING_RE` short-circuit before keyword/classifier steps.
- Tests: 6 greeting-sticky cases; 1 assertion that `story_teller` has no image tools.

## Diagnostic vs preventive
- **Fix 1 (images)** — code-level root cause confirmed from tool definition + observed UX (screenshot).
- **Fix 2 (greetings)** — preventive hardening. Specific failing transcript wasn't recoverable from the 30m prod log window on `chat-backend-b5b849955-hrmll`, so the classifier-mis-route theory isn't empirically confirmed. Still a valid behavioral guard.

## Test plan
- [x] `cd backend && npx jest` — 345/345 pass (network-bind route tests excluded due to sandbox, unrelated).
- [x] Type-check + build via pre-commit gate.
- [ ] Live QA: trigger hold flow until Story Teller is picked proactively; confirm text-only story (no gallery).
- [ ] Live QA: while on any proactive entertainment agent, send "Hello" / "hi" / "thanks"; confirm agent stays, does not flip to Customer Service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)