### PR TITLE
ops(k8s): wire YOUTUBE_API_KEY into chat-backend deployment

### DIFF
--- a/k8s/apps/chat/deployment.yaml
+++ b/k8s/apps/chat/deployment.yaml
@@ -74,6 +74,11 @@ spec:
                 secretKeyRef:
                   name: chat-secrets-from-keyvault
                   key: AZURE_FOUNDRY_ENDPOINT
+            - name: YOUTUBE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: chat-secrets-youtube
+                  key: YOUTUBE_API_KEY
           envFrom:
             - configMapRef:
                 name: chat-backend-config


### PR DESCRIPTION
## Summary
Wire `YOUTUBE_API_KEY` env ref into `chat-backend` deployment via a new `chat-secrets-youtube` opaque Secret. Unlocks live YouTube search in YouTube Guru — until this, the tool fell back to a RAG stub (`dQw4w9WgXcQ`, rickroll).

## Out-of-band (already done)
- Secret created imperatively in `default` ns:
  ```
  kubectl -n default create secret generic chat-secrets-youtube \
    --from-literal=YOUTUBE_API_KEY=<redacted>
  ```
- Deployment already applied + rolled out; pod `chat-backend-6976c897f8-pd5ts` Ready with the new env ref.

## Follow-up (not in this PR)
- Migrate `YOUTUBE_API_KEY` into Azure Key Vault + `chat-secrets-from-keyvault` SecretProviderClass so the Secret is not managed out-of-band.

## Test plan
- [x] `kubectl apply` — `deployment.apps/chat-backend configured`
- [x] Rollout complete, pod 2/2 Ready
- [x] `env` shows `YOUTUBE_API_KEY` sourced from `secretKeyRef`
- [ ] Live QA: ask YouTube Guru for a funny video → 3 real, query-matching cards (not rickroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)