### PR TITLE
fix(media): memo AudioPlayer + GifView; youtube-nocookie; max-widths

### DIFF
--- a/frontend/components/media/AudioPlayer.tsx
+++ b/frontend/components/media/AudioPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { memo, useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -21,7 +21,7 @@ function formatTime(secs: number): string {
   return `${m}:${String(s).padStart(2, '0')}`;
 }
 
-export const AudioPlayer: React.FC<AudioPlayerProps> = ({
+const AudioPlayerInner: React.FC<AudioPlayerProps> = ({
   url,
   title,
   artist,
@@ -122,6 +122,20 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
   );
 };
 
+// Memo on the identity of the source url so parent re-renders (status
+// polling, streaming chunks) don't unmount the player and kill the
+// already-loaded sound. Without this, useEffect cleanup calls
+// `sound.unloadAsync()` on every unmount → audio stops after a couple
+// seconds.
+export const AudioPlayer = memo(
+  AudioPlayerInner,
+  (prev, next) =>
+    prev.url === next.url &&
+    prev.title === next.title &&
+    prev.artist === next.artist &&
+    prev.durationSec === next.durationSec,
+);
+
 const styles = StyleSheet.create({
   container: {
     backgroundColor: ForestColors.backgroundSecondary,
@@ -130,6 +144,9 @@ const styles = StyleSheet.create({
     marginVertical: 6,
     borderWidth: 1,
     borderColor: ForestColors.brandPrimary,
+    maxWidth: 560,
+    width: '100%',
+    alignSelf: 'flex-start',
   },
   info: { marginBottom: 8 },
   title: { color: ForestColors.textNormal, fontSize: 13, fontWeight: '600' },

--- a/frontend/components/media/GifView.tsx
+++ b/frontend/components/media/GifView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { ForestColors } from '../../constants/Colors';
@@ -10,7 +10,7 @@ interface GifViewProps {
   height?: number;
 }
 
-export const GifView: React.FC<GifViewProps> = ({
+const GifViewInner: React.FC<GifViewProps> = ({
   url,
   title,
   width,
@@ -36,6 +36,18 @@ export const GifView: React.FC<GifViewProps> = ({
   );
 };
 
+// Memo on src url so the <img>/Image isn't re-created on every parent
+// re-render. Re-creation forces the browser to re-fetch the GIF (tens of
+// times during a streaming turn with devtools "disable cache" on).
+export const GifView = memo(
+  GifViewInner,
+  (prev, next) =>
+    prev.url === next.url &&
+    prev.title === next.title &&
+    prev.width === next.width &&
+    prev.height === next.height,
+);
+
 const styles = StyleSheet.create({
   container: {
     borderRadius: 12,
@@ -44,6 +56,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: ForestColors.borderLight,
     backgroundColor: ForestColors.backgroundTertiary,
+    maxWidth: 400,
+    width: '100%',
+    alignSelf: 'flex-start',
   },
   gif: { width: '100%' },
   caption: {

--- a/frontend/components/media/YouTubeEmbed.tsx
+++ b/frontend/components/media/YouTubeEmbed.tsx
@@ -39,7 +39,7 @@ const YouTubeEmbedInner: React.FC<YouTubeEmbedProps> = ({
       <View style={styles.webContainer}>
         <View style={styles.webPlayerWrapper}>
           <iframe
-            src={`https://www.youtube.com/embed/${videoId}`}
+            src={`https://www.youtube-nocookie.com/embed/${videoId}?modestbranding=1&rel=0`}
             title={title}
             frameBorder='0'
             allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'


### PR DESCRIPTION
## Summary

Followup to #179 for issues visible after deploy.

- **Audio stops after a couple seconds.** AudioPlayer was unmounting whenever the parent re-rendered (status poll / streaming chunks); its cleanup calls `sound.unloadAsync()` which hard-kills playback. Wrap in `React.memo` so props-equal re-renders skip the unmount cycle.
- **GIFs re-fetched 30+ times per turn.** The `<Image>` in GifView was re-created every render (HAR showed the same Giphy URL fetched 32× in 10s even though it was cached). Same memo treatment.
- **YouTube iframe noise.** The base.js error traces + doubleclick pixel requests reported in devtools are YouTube-internal. Switch embed host to `youtube-nocookie.com` + `modestbranding=1&rel=0` to skip most tracking pixels and quiet the logs.
- **Max widths.** AudioPlayer `maxWidth: 560`, GifView `maxWidth: 400`. Matches the YouTubeEmbed aspect-ratio fix from #179 so media cards don't stretch edge-to-edge on desktop.

## Test plan
- [x] Frontend type-check + lint clean.
- [ ] Post-deploy live QA: play an audio preview; confirm it keeps playing through a couple stream-chunks / status polls instead of stopping.
- [ ] Post-deploy live QA: trigger a GIF, watch Network tab; confirm the GIF URL is fetched once, not 30×.
- [ ] Post-deploy live QA: play a YouTube video; confirm no "base.js" error spam in console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)