### PR TITLE
feat(embed): add embeddable chat widget for external sites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,17 @@ ENV EXPO_PUBLIC_API_URL=https://chat.cat-herding.net
 # Build frontend for web
 RUN npm run build
 
+# Stage 1b: Build embeddable chat widget (vanilla TS + Vite lib bundle)
+FROM node:22-alpine3.20 AS embed-builder
+
+WORKDIR /embed
+
+COPY embed/package*.json ./
+RUN npm install --no-audit --no-fund
+
+COPY embed/ ./
+RUN npm run build
+
 # Stage 2: Build Backend (TypeScript)
 FROM node:22-alpine3.20 AS backend-builder
 
@@ -63,8 +74,10 @@ COPY --from=backend-builder --chown=nodejs:nodejs /backend/package*.json ./
 
 # Copy frontend built application into location expected by backend static server
 # Backend code serves from path: dist/backend/public
-RUN mkdir -p dist/backend/public
+RUN mkdir -p dist/backend/public dist/backend/public/embed
 COPY --from=frontend-builder --chown=nodejs:nodejs /frontend/dist ./dist/backend/public
+# Embeddable chat widget served at /embed/cat-herding-chat.js
+COPY --from=embed-builder --chown=nodejs:nodejs /embed/dist ./dist/backend/public/embed
 
 # Switch to nodejs user
 USER nodejs

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -94,6 +94,7 @@ const allowedOrigins = process.env.FRONTEND_URL
       'http://localhost:5001', // Same origin when combined
       // Production domains
       'https://chat.cat-herding.net',
+      'https://portfolio.cat-herding.net',
     ];
 
 debugLog('Creating Socket.IO server...');

--- a/backend/src/socket/__tests__/socketHandlers.test.ts
+++ b/backend/src/socket/__tests__/socketHandlers.test.ts
@@ -272,6 +272,48 @@ describe('Socket Handlers', () => {
       expect(metrics.activeConnections.inc).toHaveBeenCalled();
     });
 
+    it('should skip hold-flow bootstrap in lean mode and init general agent', () => {
+      // Fresh connection with leanMode flag (as set by io.use middleware for
+      // embed widgets passing ?mode=lean in handshake query). Clear pending
+      // timers/mocks left by the outer beforeEach so we only see calls from
+      // this lean socket.
+      jest.clearAllTimers();
+      jest.clearAllMocks();
+
+      const leanSocket: any = {
+        ...mockSocket,
+        id: 'lean-socket-id',
+        leanMode: true,
+        on: jest.fn(),
+        join: jest.fn(),
+        emit: jest.fn(),
+        to: jest.fn().mockReturnThis(),
+      };
+
+      // Re-acquire connection handler (mockIo.on was cleared)
+      setupSocketHandlers(mockIo);
+      const handler = (mockIo.on as jest.Mock).mock.calls.find(
+        call => call[0] === 'connection',
+      )[1];
+      handler(leanSocket);
+
+      // Advance the 500ms initStateTimeout so the branch executes.
+      jest.advanceTimersByTime(600);
+
+      // Lean mode should initialize the conversation with 'general', not
+      // 'hold_agent', and should not emit a hold_greeting proactive message.
+      const initCalls = (agentService.initializeConversation as jest.Mock).mock
+        .calls;
+      expect(initCalls.some(c => c[0] === 'lean-socket-id' && c[1] === 'general'))
+        .toBe(true);
+      expect(initCalls.some(c => c[1] === 'hold_agent')).toBe(false);
+
+      const proactiveEmits = (leanSocket.emit as jest.Mock).mock.calls.filter(
+        c => c[0] === 'proactive_message',
+      );
+      expect(proactiveEmits).toHaveLength(0);
+    });
+
     it('should properly clean up on disconnect', () => {
       // Get disconnect handler
       const disconnectCalls = (mockSocket.on as jest.Mock).mock.calls.filter(

--- a/backend/src/socket/__tests__/socketHandlers.test.ts
+++ b/backend/src/socket/__tests__/socketHandlers.test.ts
@@ -304,8 +304,9 @@ describe('Socket Handlers', () => {
       // 'hold_agent', and should not emit a hold_greeting proactive message.
       const initCalls = (agentService.initializeConversation as jest.Mock).mock
         .calls;
-      expect(initCalls.some(c => c[0] === 'lean-socket-id' && c[1] === 'general'))
-        .toBe(true);
+      expect(
+        initCalls.some(c => c[0] === 'lean-socket-id' && c[1] === 'general'),
+      ).toBe(true);
       expect(initCalls.some(c => c[1] === 'hold_agent')).toBe(false);
 
       const proactiveEmits = (leanSocket.emit as jest.Mock).mock.calls.filter(

--- a/backend/src/socket/socketHandlers.ts
+++ b/backend/src/socket/socketHandlers.ts
@@ -21,6 +21,10 @@ import { tracingContextManager } from '../tracing/contextManager';
 interface AuthenticatedSocket extends Socket {
   userId?: string;
   userEmail?: string;
+  // When set via handshake query `?mode=lean`, suppresses the demo
+  // hold-flow bootstrap so embedded widgets don't auto-push unsolicited
+  // proactive messages (joke/gif/youtube) to visitors.
+  leanMode?: boolean;
 }
 
 // Helper function to generate conversation title
@@ -210,6 +214,13 @@ export const setupSocketHandlers = (
   io.use(async (socket: AuthenticatedSocket, next) => {
     try {
       const token = socket.handshake.auth.token || socket.handshake.query.token;
+
+      // Embed-widget opt-out of the demo hold-flow auto-bootstrap.
+      const modeQuery = socket.handshake.query.mode;
+      const mode = Array.isArray(modeQuery) ? modeQuery[0] : modeQuery;
+      if (mode === 'lean') {
+        socket.leanMode = true;
+      }
 
       // Check for oauth2-proxy headers first (passed through from Istio/oauth2-proxy)
       const proxyEmail = socket.handshake.headers['x-auth-request-email'] as
@@ -548,8 +559,17 @@ export const setupSocketHandlers = (
     // Store intervals for cleanup
     const intervals = [statusInterval];
 
-    // Initialize user state for goal-seeking system and hold agent
+    // Initialize user state for goal-seeking system and hold agent.
+    // Lean-mode clients (embed widget) skip this bootstrap so visitors
+    // don't get unsolicited hold-flow proactive messages.
     const initStateTimeout = setTimeout(async () => {
+      if (socket.leanMode) {
+        console.log(
+          `🧭 Lean mode: skipping hold-flow bootstrap for ${socket.id}`,
+        );
+        agentService.initializeConversation(socket.id, 'general');
+        return;
+      }
       try {
         console.log(`🎯 Initializing user state for ${socket.id}`);
 

--- a/embed/.gitignore
+++ b/embed/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.npm-cache
+*.log

--- a/embed/README.md
+++ b/embed/README.md
@@ -1,0 +1,75 @@
+# Cat-Herding Chat Embed
+
+Embeddable, drop-in floating chat widget backed by the Cat-Herding AI demo backend. Intended for sites such as `portfolio.cat-herding.net` that want a chat bubble in the corner without pulling in the full React Native / Expo SPA.
+
+## Install on a host page
+
+Add the script tag and call `init()`:
+
+```html
+<script src="https://chat.cat-herding.net/embed/cat-herding-chat.js" defer></script>
+<script>
+  window.addEventListener('load', () => {
+    window.CatHerdingChat.init({
+      apiUrl: 'https://chat.cat-herding.net',
+      title: 'Ask about my portfolio',
+      subtitle: 'AI demo',
+      position: 'bottom-right',
+      accentColor: '#4f46e5',
+      mode: 'lean',
+    });
+  });
+</script>
+```
+
+### Content Security Policy
+
+If the host page enforces a CSP, allow:
+
+- `script-src https://chat.cat-herding.net`
+- `connect-src https://chat.cat-herding.net wss://chat.cat-herding.net`
+- `frame-src https://www.youtube-nocookie.com` (only if you want YouTube attachments to render)
+- `img-src data: https:` (for inbound GIF attachments)
+
+## Options
+
+| Option           | Type                                                           | Default               | Description                                                                                                              |
+| ---------------- | -------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `apiUrl`         | `string` (required)                                            | —                     | Origin of the chat backend, e.g. `https://chat.cat-herding.net`.                                                         |
+| `mode`           | `'lean' \| 'demo'`                                             | `'lean'`              | `'lean'` skips the demo hold-flow auto-bootstrap (no unsolicited joke/GIF). `'demo'` opts into the full demo experience. |
+| `title`          | `string`                                                       | `'Cat-Herding Chat'`  | Header title.                                                                                                            |
+| `subtitle`       | `string`                                                       | `'AI portfolio demo'` | Header subtitle.                                                                                                         |
+| `position`       | `'bottom-right' \| 'bottom-left' \| 'top-right' \| 'top-left'` | `'bottom-right'`      | Screen corner for the launcher.                                                                                          |
+| `accentColor`    | `string`                                                       | `'#4f46e5'`           | Button / header / user bubble color.                                                                                     |
+| `openOnLoad`     | `boolean`                                                      | `false`               | Open the panel immediately.                                                                                              |
+| `placeholder`    | `string`                                                       | `'Ask me anything…'`  | Text for the input placeholder.                                                                                          |
+| `welcomeMessage` | `string \| null`                                               | short welcome         | First bubble shown. Pass `null` to omit.                                                                                 |
+| `footerHtml`     | `string \| null`                                               | link to repo          | HTML rendered in the footer. Pass `null` to omit.                                                                        |
+
+`CatHerdingChat.init()` returns the `ChatWidget` instance. The widget also exposes `open()`, `close()`, `toggle()`, and `destroy()` methods.
+
+## Isolation
+
+The widget mounts inside a Shadow DOM so host-page CSS does not bleed in and widget styles do not bleed out. It does not load any global fonts; it inherits the system font stack.
+
+## Auth
+
+The widget connects anonymously to `wss://$apiUrl/api/socket.io`. The backend's Socket.IO path is wired to accept anonymous connections; no login flow is needed on the host site.
+
+## Development
+
+```bash
+cd embed
+npm install
+npm run dev          # starts Vite dev server at http://localhost:5199/demo/
+# ensure backend is running separately: cd backend && npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+# outputs: dist/cat-herding-chat.js + dist/cat-herding-chat.css + sourcemap
+```
+
+The Docker build copies `dist/` into `dist/backend/public/embed/` so the bundle is served at `https://chat.cat-herding.net/embed/cat-herding-chat.js`.

--- a/embed/demo/index.html
+++ b/embed/demo/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cat-Herding Chat Embed — Example</title>
+    <style>
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        max-width: 720px;
+        margin: 60px auto;
+        padding: 0 20px;
+        color: #111827;
+        line-height: 1.6;
+      }
+      pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 16px;
+        border-radius: 8px;
+        overflow: auto;
+      }
+      code {
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cat-Herding Chat Embed</h1>
+    <p>
+      Drop-in floating chat widget. Floating button bottom-right — click it to
+      open the chat panel. This page mounts against a local backend for dev.
+    </p>
+    <pre><code>&lt;script src="https://chat.cat-herding.net/embed/cat-herding-chat.js" defer&gt;&lt;/script&gt;
+&lt;script&gt;
+  window.addEventListener('load', () =&gt; {
+    window.CatHerdingChat.init({
+      apiUrl: 'https://chat.cat-herding.net',
+      title: 'Ask about my portfolio',
+      mode: 'lean'
+    });
+  });
+&lt;/script&gt;</code></pre>
+
+    <!-- Vite dev entry -->
+    <script type="module" src="/src/index.ts"></script>
+    <script>
+      window.addEventListener('load', () => {
+        window.CatHerdingChat.init({
+          apiUrl: 'http://localhost:5001',
+          title: 'Portfolio chat (dev)',
+          subtitle: 'Local backend',
+          mode: 'lean',
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/embed/package-lock.json
+++ b/embed/package-lock.json
@@ -1,0 +1,1113 @@
+{
+  "name": "@cat-herding/chat-embed",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cat-herding/chat-embed",
+      "version": "0.1.0",
+      "dependencies": {
+        "socket.io-client": "^4.7.5"
+      },
+      "devDependencies": {
+        "typescript": "~5.8.3",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@cat-herding/chat-embed",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Embeddable Cat-Herding chat widget. Drop-in floating chat for any website.",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"src/**/*.{ts,css,html}\" README.md",
+    "format:check": "prettier --check \"src/**/*.{ts,css,html}\" README.md"
+  },
+  "dependencies": {
+    "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/embed/src/icons.ts
+++ b/embed/src/icons.ts
@@ -1,0 +1,12 @@
+export const chatIcon = /* svg */ `
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+</svg>
+`;
+
+export const closeIcon = /* svg */ `
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <line x1="18" y1="6" x2="6" y2="18"/>
+  <line x1="6" y1="6" x2="18" y2="18"/>
+</svg>
+`;

--- a/embed/src/index.ts
+++ b/embed/src/index.ts
@@ -1,0 +1,31 @@
+import { ChatWidget, ChatWidgetOptions } from './widget';
+
+declare global {
+  interface Window {
+    CatHerdingChat?: CatHerdingChatApi;
+  }
+}
+
+interface CatHerdingChatApi {
+  init(options: ChatWidgetOptions): ChatWidget;
+  widget?: ChatWidget;
+}
+
+const api: CatHerdingChatApi = {
+  init(options: ChatWidgetOptions): ChatWidget {
+    if (api.widget) {
+      api.widget.destroy();
+    }
+    const w = new ChatWidget(options);
+    w.mount();
+    api.widget = w;
+    return w;
+  },
+};
+
+if (typeof window !== 'undefined') {
+  window.CatHerdingChat = api;
+}
+
+export { ChatWidget, api };
+export type { ChatWidgetOptions } from './widget';

--- a/embed/src/styles.ts
+++ b/embed/src/styles.ts
@@ -1,0 +1,221 @@
+export const widgetCss = /* css */ `
+:host {
+  all: initial;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  color: #111827;
+  line-height: 1.4;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+.root {
+  position: fixed;
+  z-index: 2147483000;
+  font-size: 14px;
+}
+.root.pos-br { right: 20px; bottom: 20px; }
+.root.pos-bl { left: 20px; bottom: 20px; }
+.root.pos-tr { right: 20px; top: 20px; }
+.root.pos-tl { left: 20px; top: 20px; }
+
+.fab {
+  width: 56px;
+  height: 56px;
+  border-radius: 9999px;
+  border: none;
+  background: var(--ch-accent, #4f46e5);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+.fab:hover { transform: translateY(-1px); box-shadow: 0 14px 30px rgba(0, 0, 0, 0.2); }
+.fab:focus-visible { outline: 3px solid rgba(79, 70, 229, 0.4); outline-offset: 2px; }
+.fab svg { width: 24px; height: 24px; }
+
+.panel {
+  position: absolute;
+  width: min(380px, calc(100vw - 40px));
+  height: min(600px, calc(100vh - 100px));
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+  display: none;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+}
+.root.pos-br .panel { right: 0; bottom: 72px; }
+.root.pos-bl .panel { left: 0; bottom: 72px; }
+.root.pos-tr .panel { right: 0; top: 72px; }
+.root.pos-tl .panel { left: 0; top: 72px; }
+.root.open .panel { display: flex; }
+.root.open .fab { display: none; }
+
+.header {
+  background: var(--ch-accent, #4f46e5);
+  color: #fff;
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.header .title { font-weight: 600; font-size: 15px; flex: 1; }
+.header .sub { font-size: 12px; opacity: 0.85; }
+.header .close {
+  background: transparent;
+  border: none;
+  color: #fff;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.header .close:hover { background: rgba(255,255,255,0.15); }
+.header .close svg { width: 18px; height: 18px; }
+
+.status {
+  padding: 6px 12px;
+  font-size: 11px;
+  color: #6b7280;
+  background: #f9fafb;
+  border-bottom: 1px solid #f3f4f6;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 26px;
+}
+.status .dot { width: 8px; height: 8px; border-radius: 50%; background: #9ca3af; }
+.status.connected .dot { background: #10b981; }
+.status.error .dot { background: #ef4444; }
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  background: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.msg {
+  max-width: 85%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  font-size: 14px;
+  line-height: 1.45;
+}
+.msg.user {
+  align-self: flex-end;
+  background: var(--ch-accent, #4f46e5);
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+.msg.assistant {
+  align-self: flex-start;
+  background: #fff;
+  color: #111827;
+  border: 1px solid #e5e7eb;
+  border-bottom-left-radius: 4px;
+}
+.msg .agent-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: #eef2ff;
+  color: #4338ca;
+  padding: 2px 6px;
+  border-radius: 999px;
+  margin-bottom: 6px;
+}
+
+.attachment {
+  margin-top: 8px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #000;
+}
+.attachment img { width: 100%; display: block; max-height: 240px; object-fit: cover; }
+.attachment iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: none;
+  display: block;
+}
+
+.typing {
+  align-self: flex-start;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border-bottom-left-radius: 4px;
+  display: flex;
+  gap: 4px;
+}
+.typing span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #9ca3af;
+  animation: ch-bounce 1.2s infinite;
+}
+.typing span:nth-child(2) { animation-delay: 0.15s; }
+.typing span:nth-child(3) { animation-delay: 0.3s; }
+@keyframes ch-bounce {
+  0%, 80%, 100% { transform: scale(0.6); opacity: 0.6; }
+  40% { transform: scale(1); opacity: 1; }
+}
+
+.input-row {
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  background: #fff;
+  border-top: 1px solid #e5e7eb;
+}
+.input-row input {
+  flex: 1;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  outline: none;
+  font-family: inherit;
+  color: inherit;
+}
+.input-row input:focus { border-color: var(--ch-accent, #4f46e5); box-shadow: 0 0 0 3px rgba(79,70,229,0.15); }
+.input-row button {
+  border: none;
+  background: var(--ch-accent, #4f46e5);
+  color: #fff;
+  padding: 0 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.input-row button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.footer {
+  font-size: 10px;
+  color: #9ca3af;
+  padding: 4px 10px 8px;
+  text-align: center;
+  background: #fff;
+}
+.footer a { color: inherit; text-decoration: none; }
+.footer a:hover { text-decoration: underline; }
+`;

--- a/embed/src/widget.ts
+++ b/embed/src/widget.ts
@@ -265,37 +265,44 @@ export class ChatWidget {
       }
     });
 
-    this.socket.on('stream_complete', (data: { messageId: string; conversationId: string; agentUsed?: string }) => {
-      if (data.conversationId) this.conversationId = data.conversationId;
-      const el = this.streamingMessages.get(data.messageId);
-      if (el && data.agentUsed) this.applyAgentBadge(el, data.agentUsed);
-      this.streamingMessages.delete(data.messageId);
-      this.sendBtn.disabled = this.inputEl.value.trim().length === 0;
-    });
-
-    this.socket.on('stream_error', (err: { message: string; code?: string }) => {
-      this.removeTyping();
-      // Backend uses in-memory storage; on a restart a previously valid
-      // conversationId stops existing. Drop it so the next send creates a
-      // fresh conversation instead of dead-ending on the same error.
-      if (err.code === 'CONVERSATION_NOT_FOUND') {
-        this.conversationId = null;
-      }
-      this.appendAssistantFinal({
-        id: `err-${Date.now()}`,
-        role: 'assistant',
-        content: `Sorry, something went wrong: ${err.message}`,
-      });
-      this.sendBtn.disabled = this.inputEl.value.trim().length === 0;
-    });
-
     this.socket.on(
-      'proactive_message',
-      (data: { message: ServerMessage }) => {
-        this.removeTyping();
-        this.appendAssistantFinal(data.message);
+      'stream_complete',
+      (data: {
+        messageId: string;
+        conversationId: string;
+        agentUsed?: string;
+      }) => {
+        if (data.conversationId) this.conversationId = data.conversationId;
+        const el = this.streamingMessages.get(data.messageId);
+        if (el && data.agentUsed) this.applyAgentBadge(el, data.agentUsed);
+        this.streamingMessages.delete(data.messageId);
+        this.sendBtn.disabled = this.inputEl.value.trim().length === 0;
       },
     );
+
+    this.socket.on(
+      'stream_error',
+      (err: { message: string; code?: string }) => {
+        this.removeTyping();
+        // Backend uses in-memory storage; on a restart a previously valid
+        // conversationId stops existing. Drop it so the next send creates a
+        // fresh conversation instead of dead-ending on the same error.
+        if (err.code === 'CONVERSATION_NOT_FOUND') {
+          this.conversationId = null;
+        }
+        this.appendAssistantFinal({
+          id: `err-${Date.now()}`,
+          role: 'assistant',
+          content: `Sorry, something went wrong: ${err.message}`,
+        });
+        this.sendBtn.disabled = this.inputEl.value.trim().length === 0;
+      },
+    );
+
+    this.socket.on('proactive_message', (data: { message: ServerMessage }) => {
+      this.removeTyping();
+      this.appendAssistantFinal(data.message);
+    });
 
     this.socket.on(
       'attachment',
@@ -382,7 +389,10 @@ export class ChatWidget {
     if (attachment.type === 'youtube' && attachment.videoId) {
       const iframe = document.createElement('iframe');
       iframe.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(attachment.videoId)}`;
-      iframe.setAttribute('allow', 'accelerometer; encrypted-media; picture-in-picture');
+      iframe.setAttribute(
+        'allow',
+        'accelerometer; encrypted-media; picture-in-picture',
+      );
       iframe.setAttribute('allowfullscreen', '');
       iframe.setAttribute('referrerpolicy', 'no-referrer-when-downgrade');
       wrap.appendChild(iframe);

--- a/embed/src/widget.ts
+++ b/embed/src/widget.ts
@@ -1,0 +1,428 @@
+import { io, Socket } from 'socket.io-client';
+import { widgetCss } from './styles';
+import { chatIcon, closeIcon } from './icons';
+
+export type WidgetPosition =
+  | 'bottom-right'
+  | 'bottom-left'
+  | 'top-right'
+  | 'top-left';
+
+export interface ChatWidgetOptions {
+  apiUrl: string;
+  title?: string;
+  subtitle?: string;
+  position?: WidgetPosition;
+  accentColor?: string;
+  mode?: 'lean' | 'demo';
+  openOnLoad?: boolean;
+  placeholder?: string;
+  footerHtml?: string | null;
+  welcomeMessage?: string | null;
+}
+
+interface Attachment {
+  type: 'youtube' | 'gif' | string;
+  videoId?: string;
+  url?: string;
+  title?: string;
+  altText?: string;
+}
+
+interface ServerMessage {
+  id: string;
+  content: string;
+  role: 'user' | 'assistant';
+  conversationId?: string;
+  agentUsed?: string;
+  confidence?: number;
+  attachments?: Attachment[];
+  isProactive?: boolean;
+}
+
+interface StreamChunk {
+  id: string;
+  content: string;
+  conversationId: string;
+  messageId: string;
+  isComplete: boolean;
+}
+
+const POSITION_CLASS: Record<WidgetPosition, string> = {
+  'bottom-right': 'pos-br',
+  'bottom-left': 'pos-bl',
+  'top-right': 'pos-tr',
+  'top-left': 'pos-tl',
+};
+
+const DEFAULTS: Required<
+  Omit<ChatWidgetOptions, 'apiUrl' | 'footerHtml' | 'welcomeMessage'>
+> & { footerHtml: string | null; welcomeMessage: string | null } = {
+  title: 'Cat-Herding Chat',
+  subtitle: 'AI portfolio demo',
+  position: 'bottom-right',
+  accentColor: '#4f46e5',
+  mode: 'lean',
+  openOnLoad: false,
+  placeholder: 'Ask me anything…',
+  footerHtml:
+    'Demo powered by <a href="https://github.com/ianlintner/Example-React-AI-Chat-App" target="_blank" rel="noopener">cat-herding</a>',
+  welcomeMessage:
+    "Hi! I'm an AI demo. Ask about the portfolio, say hi, or request a joke.",
+};
+
+export class ChatWidget {
+  private readonly opts: ChatWidgetOptions &
+    typeof DEFAULTS & { apiUrl: string };
+  private host!: HTMLElement;
+  private root!: HTMLDivElement;
+  private messagesEl!: HTMLDivElement;
+  private inputEl!: HTMLInputElement;
+  private sendBtn!: HTMLButtonElement;
+  private statusEl!: HTMLDivElement;
+  private typingEl: HTMLDivElement | null = null;
+  private socket: Socket | null = null;
+  private conversationId: string | null = null;
+  private streamingMessages = new Map<string, HTMLDivElement>();
+
+  constructor(opts: ChatWidgetOptions) {
+    if (!opts || !opts.apiUrl) {
+      throw new Error('CatHerdingChat: apiUrl is required');
+    }
+    this.opts = { ...DEFAULTS, ...opts };
+  }
+
+  mount(target: HTMLElement = document.body): void {
+    this.host = document.createElement('div');
+    this.host.setAttribute('data-cat-herding-chat', '');
+    const shadow = this.host.attachShadow({ mode: 'open' });
+    const style = document.createElement('style');
+    style.textContent = widgetCss;
+    shadow.appendChild(style);
+
+    this.root = document.createElement('div');
+    this.root.className = `root ${POSITION_CLASS[this.opts.position]}`;
+    this.root.style.setProperty('--ch-accent', this.opts.accentColor);
+    shadow.appendChild(this.root);
+
+    this.renderLauncher();
+    this.renderPanel();
+
+    target.appendChild(this.host);
+
+    if (this.opts.openOnLoad) {
+      this.open();
+    }
+  }
+
+  destroy(): void {
+    this.socket?.disconnect();
+    this.socket = null;
+    this.host?.remove();
+  }
+
+  open(): void {
+    this.root.classList.add('open');
+    this.ensureConnected();
+    setTimeout(() => this.inputEl?.focus(), 50);
+  }
+
+  close(): void {
+    this.root.classList.remove('open');
+  }
+
+  toggle(): void {
+    if (this.root.classList.contains('open')) this.close();
+    else this.open();
+  }
+
+  private renderLauncher(): void {
+    const btn = document.createElement('button');
+    btn.className = 'fab';
+    btn.setAttribute('aria-label', 'Open chat');
+    btn.innerHTML = chatIcon;
+    btn.addEventListener('click', () => this.open());
+    this.root.appendChild(btn);
+  }
+
+  private renderPanel(): void {
+    const panel = document.createElement('div');
+    panel.className = 'panel';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-label', this.opts.title);
+    this.root.appendChild(panel);
+
+    const header = document.createElement('div');
+    header.className = 'header';
+    header.innerHTML = `
+      <div style="flex:1">
+        <div class="title"></div>
+        <div class="sub"></div>
+      </div>
+      <button class="close" aria-label="Close chat">${closeIcon}</button>
+    `;
+    (header.querySelector('.title') as HTMLElement).textContent =
+      this.opts.title;
+    (header.querySelector('.sub') as HTMLElement).textContent =
+      this.opts.subtitle;
+    header
+      .querySelector('.close')!
+      .addEventListener('click', () => this.close());
+    panel.appendChild(header);
+
+    this.statusEl = document.createElement('div');
+    this.statusEl.className = 'status';
+    this.statusEl.innerHTML = `<span class="dot"></span><span class="text">Connecting…</span>`;
+    panel.appendChild(this.statusEl);
+
+    this.messagesEl = document.createElement('div');
+    this.messagesEl.className = 'messages';
+    panel.appendChild(this.messagesEl);
+
+    if (this.opts.welcomeMessage) {
+      this.appendAssistantFinal({
+        id: 'welcome',
+        role: 'assistant',
+        content: this.opts.welcomeMessage,
+      });
+    }
+
+    const inputRow = document.createElement('form');
+    inputRow.className = 'input-row';
+    inputRow.innerHTML = `
+      <input type="text" autocomplete="off" spellcheck="true" />
+      <button type="submit" disabled>Send</button>
+    `;
+    this.inputEl = inputRow.querySelector('input')!;
+    this.sendBtn = inputRow.querySelector('button')!;
+    this.inputEl.placeholder = this.opts.placeholder;
+
+    this.inputEl.addEventListener('input', () => {
+      this.sendBtn.disabled = this.inputEl.value.trim().length === 0;
+    });
+    inputRow.addEventListener('submit', e => {
+      e.preventDefault();
+      this.handleSend();
+    });
+    panel.appendChild(inputRow);
+
+    if (this.opts.footerHtml) {
+      const footer = document.createElement('div');
+      footer.className = 'footer';
+      footer.innerHTML = this.opts.footerHtml;
+      panel.appendChild(footer);
+    }
+  }
+
+  private setStatus(
+    state: 'connecting' | 'connected' | 'error',
+    text: string,
+  ): void {
+    this.statusEl.classList.remove('connected', 'error');
+    if (state !== 'connecting') this.statusEl.classList.add(state);
+    const t = this.statusEl.querySelector('.text') as HTMLElement;
+    t.textContent = text;
+  }
+
+  private ensureConnected(): void {
+    if (this.socket?.connected || this.socket?.active) return;
+
+    const query: Record<string, string> = {};
+    if (this.opts.mode === 'lean') query.mode = 'lean';
+
+    this.setStatus('connecting', 'Connecting…');
+
+    this.socket = io(this.opts.apiUrl, {
+      path: '/api/socket.io',
+      transports: ['websocket', 'polling'],
+      withCredentials: true,
+      query,
+      reconnectionAttempts: 5,
+      timeout: 15000,
+    });
+
+    this.socket.on('connect', () => {
+      this.setStatus('connected', 'Connected');
+    });
+    this.socket.on('disconnect', reason => {
+      this.setStatus('error', `Disconnected (${reason})`);
+    });
+    this.socket.on('connect_error', err => {
+      this.setStatus('error', `Connection error: ${err.message}`);
+    });
+
+    this.socket.on('stream_start', (data: { messageId: string }) => {
+      this.removeTyping();
+      const el = this.createAssistantBubble('');
+      this.streamingMessages.set(data.messageId, el);
+    });
+
+    this.socket.on('stream_chunk', (chunk: StreamChunk) => {
+      const el = this.streamingMessages.get(chunk.messageId);
+      if (el) {
+        this.setAssistantText(el, chunk.content);
+        this.scrollToBottom();
+      }
+    });
+
+    this.socket.on('stream_complete', (data: { messageId: string; conversationId: string; agentUsed?: string }) => {
+      if (data.conversationId) this.conversationId = data.conversationId;
+      const el = this.streamingMessages.get(data.messageId);
+      if (el && data.agentUsed) this.applyAgentBadge(el, data.agentUsed);
+      this.streamingMessages.delete(data.messageId);
+      this.sendBtn.disabled = this.inputEl.value.trim().length === 0;
+    });
+
+    this.socket.on('stream_error', (err: { message: string; code?: string }) => {
+      this.removeTyping();
+      // Backend uses in-memory storage; on a restart a previously valid
+      // conversationId stops existing. Drop it so the next send creates a
+      // fresh conversation instead of dead-ending on the same error.
+      if (err.code === 'CONVERSATION_NOT_FOUND') {
+        this.conversationId = null;
+      }
+      this.appendAssistantFinal({
+        id: `err-${Date.now()}`,
+        role: 'assistant',
+        content: `Sorry, something went wrong: ${err.message}`,
+      });
+      this.sendBtn.disabled = this.inputEl.value.trim().length === 0;
+    });
+
+    this.socket.on(
+      'proactive_message',
+      (data: { message: ServerMessage }) => {
+        this.removeTyping();
+        this.appendAssistantFinal(data.message);
+      },
+    );
+
+    this.socket.on(
+      'attachment',
+      (data: { messageId: string; attachment: Attachment }) => {
+        const el = this.streamingMessages.get(data.messageId);
+        if (el) this.appendAttachment(el, data.attachment);
+      },
+    );
+
+    this.socket.on(
+      'handoff_event',
+      (evt: { toAgent: string; message: string }) => {
+        this.appendAssistantFinal({
+          id: `handoff-${Date.now()}`,
+          role: 'assistant',
+          content: evt.message || `Transferring you to ${evt.toAgent}…`,
+          agentUsed: evt.toAgent,
+        });
+      },
+    );
+  }
+
+  private handleSend(): void {
+    const text = this.inputEl.value.trim();
+    if (!text || !this.socket) return;
+    this.ensureConnected();
+
+    this.appendUserMessage(text);
+    this.inputEl.value = '';
+    this.sendBtn.disabled = true;
+    this.showTyping();
+
+    this.socket.emit('stream_chat', {
+      message: text,
+      conversationId: this.conversationId || undefined,
+    });
+  }
+
+  private appendUserMessage(text: string): void {
+    const el = document.createElement('div');
+    el.className = 'msg user';
+    el.textContent = text;
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  private createAssistantBubble(initial: string): HTMLDivElement {
+    const el = document.createElement('div');
+    el.className = 'msg assistant';
+    const body = document.createElement('div');
+    body.className = 'body';
+    body.textContent = initial;
+    el.appendChild(body);
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+    return el;
+  }
+
+  private setAssistantText(el: HTMLDivElement, text: string): void {
+    const body = el.querySelector('.body') as HTMLElement | null;
+    if (body) body.textContent = text;
+  }
+
+  private applyAgentBadge(el: HTMLDivElement, agent: string): void {
+    if (el.querySelector('.agent-badge')) return;
+    const badge = document.createElement('span');
+    badge.className = 'agent-badge';
+    badge.textContent = agent.replace(/_/g, ' ');
+    el.insertBefore(badge, el.firstChild);
+  }
+
+  private appendAssistantFinal(msg: ServerMessage): void {
+    const el = this.createAssistantBubble(msg.content || '');
+    if (msg.agentUsed) this.applyAgentBadge(el, msg.agentUsed);
+    if (msg.attachments?.length) {
+      for (const a of msg.attachments) this.appendAttachment(el, a);
+    }
+  }
+
+  private appendAttachment(el: HTMLDivElement, attachment: Attachment): void {
+    const wrap = document.createElement('div');
+    wrap.className = 'attachment';
+
+    if (attachment.type === 'youtube' && attachment.videoId) {
+      const iframe = document.createElement('iframe');
+      iframe.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(attachment.videoId)}`;
+      iframe.setAttribute('allow', 'accelerometer; encrypted-media; picture-in-picture');
+      iframe.setAttribute('allowfullscreen', '');
+      iframe.setAttribute('referrerpolicy', 'no-referrer-when-downgrade');
+      wrap.appendChild(iframe);
+    } else if (attachment.type === 'gif' && attachment.url) {
+      const img = document.createElement('img');
+      img.src = attachment.url;
+      img.alt = attachment.altText || attachment.title || 'gif';
+      img.loading = 'lazy';
+      wrap.appendChild(img);
+    } else if (attachment.url) {
+      const a = document.createElement('a');
+      a.href = attachment.url;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.textContent = attachment.title || attachment.url;
+      wrap.appendChild(a);
+    } else {
+      return;
+    }
+
+    el.appendChild(wrap);
+    this.scrollToBottom();
+  }
+
+  private showTyping(): void {
+    this.removeTyping();
+    const el = document.createElement('div');
+    el.className = 'typing';
+    el.innerHTML = '<span></span><span></span><span></span>';
+    this.messagesEl.appendChild(el);
+    this.typingEl = el;
+    this.scrollToBottom();
+  }
+
+  private removeTyping(): void {
+    this.typingEl?.remove();
+    this.typingEl = null;
+  }
+
+  private scrollToBottom(): void {
+    this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+  }
+}

--- a/embed/tsconfig.json
+++ b/embed/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": []
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"]
+}

--- a/embed/vite.config.ts
+++ b/embed/vite.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: true,
+    target: 'es2019',
+    cssCodeSplit: false,
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'CatHerdingChat',
+      formats: ['iife'],
+      fileName: () => 'cat-herding-chat.js',
+    },
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: true,
+        extend: true,
+      },
+    },
+  },
+  publicDir: false,
+  server: {
+    port: 5199,
+    open: '/demo/index.html',
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `embed/` — vanilla-TS, Vite-built IIFE bundle (~17 KB gzipped) that mounts a floating chat launcher on any host page and talks to the existing Socket.IO backend anonymously. Shadow DOM isolation keeps host-page CSS and widget CSS from fighting each other.
- Adds a `?mode=lean` socket handshake query that skips the demo hold-flow auto-bootstrap, so portfolio embeds do not trigger unsolicited joke/GIF/YouTube proactive messages on connect.
- `Dockerfile` gains an `embed-builder` stage that copies the build output into `dist/backend/public/embed/`, so the bundle is served at `/embed/cat-herding-chat.js` alongside the main SPA.
- Adds `https://portfolio.cat-herding.net` to the dev CORS allowlist.

## Host page usage

```html
<script src="https://chat.cat-herding.net/embed/cat-herding-chat.js" defer></script>
<script>
  window.addEventListener('load', () => {
    window.CatHerdingChat.init({
      apiUrl: 'https://chat.cat-herding.net',
      title: 'Ask about my portfolio',
      mode: 'lean',
    });
  });
</script>
```

See `embed/README.md` for the full option list (`position`, `accentColor`, `welcomeMessage`, `footerHtml`, etc.) and CSP requirements.

## Test plan

- [x] `embed`: `tsc --noEmit` clean, `vite build` clean (55.5 KB raw / 17.3 KB gzipped)
- [x] `backend`: `npm run typecheck` + `npm run lint` clean
- [x] `backend`: socket test suite 26/26 passing, including a new `lean-mode skips hold-flow bootstrap` test
- [x] Pre-commit hook ran full `type-check` + `build` gate
- [ ] Local smoke test: `cd backend && npm run dev` in one terminal, `cd embed && npm install && npm run dev` in another, open http://localhost:5199/demo/, click FAB, send a message, confirm streaming tokens render and no unsolicited proactive message fires
- [ ] Post-deploy: curl `https://chat.cat-herding.net/embed/cat-herding-chat.js` returns 200, then embed on `portfolio.cat-herding.net` and repeat the smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)