### PR TITLE
feat(embed): OAuth2 + PKCE sign-in for the chat widget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,10 +74,12 @@ COPY --from=backend-builder --chown=nodejs:nodejs /backend/package*.json ./
 
 # Copy frontend built application into location expected by backend static server
 # Backend code serves from path: dist/backend/public
-RUN mkdir -p dist/backend/public dist/backend/public/embed
+RUN mkdir -p dist/backend/public
 COPY --from=frontend-builder --chown=nodejs:nodejs /frontend/dist ./dist/backend/public
-# Embeddable chat widget served at /embed/cat-herding-chat.js
-COPY --from=embed-builder --chown=nodejs:nodejs /embed/dist ./dist/backend/public/embed
+# Embeddable chat widget + OAuth2 callback page served at /embed/* .
+# The embed build emits under `dist/embed/` so we copy the whole tree into
+# the backend's `public/` dir to preserve the /embed/ prefix.
+COPY --from=embed-builder --chown=nodejs:nodejs /embed/dist ./dist/backend/public
 
 # Switch to nodejs user
 USER nodejs

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import agentTestBenchRoutes from './routes/agentTestBench';
 import { createSwaggerSpec, registerSwaggerRoutes } from './routes/swaggerDocs';
 import messageQueueRoutes from './routes/messageQueue';
 import authRoutes from './routes/auth';
+import embedAuthRoutes from './routes/embedAuth';
 import { setupSocketHandlers } from './socket/socketHandlers';
 import { httpMetricsMiddleware, register } from './metrics/prometheus';
 import { createQueueService } from './messageQueue/queueService';
@@ -129,6 +130,11 @@ app.use(apiRateLimiter);
 
 // Routes - Authentication (public)
 app.use('/api/auth', authRoutes);
+
+// Embed widget OAuth2 token-exchange proxy (public by design — user is
+// mid sign-in so no authenticateToken is applied; endpoint is rate-limited
+// inside the router).
+app.use('/api/auth/embed', embedAuthRoutes);
 
 // Protected routes - require authentication
 app.use('/api/chat', authenticateToken, chatRateLimiter, chatRoutes);

--- a/backend/src/routes/__tests__/embedAuth.test.ts
+++ b/backend/src/routes/__tests__/embedAuth.test.ts
@@ -1,0 +1,106 @@
+import request from 'supertest';
+import express from 'express';
+import embedAuthRouter from '../embedAuth';
+
+describe('Embed Auth Token Exchange', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth/embed', embedAuthRouter);
+
+  const origFetch = global.fetch;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = origFetch;
+    jest.resetAllMocks();
+  });
+
+  const mkResponse = (status: number, body: unknown) =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => JSON.stringify(body),
+    }) as unknown as Response;
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await request(app).post('/api/auth/embed/token').send({
+      code: 'x',
+      // code_verifier, redirect_uri, client_id missing
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards valid exchanges to the issuer and strips refresh_token', async () => {
+    fetchMock.mockResolvedValue(
+      mkResponse(200, {
+        access_token: 'abc.def.ghi',
+        id_token: 'id.jwt.here',
+        refresh_token: 'long-lived-secret',
+        expires_in: 1800,
+        token_type: 'Bearer',
+      }),
+    );
+
+    const res = await request(app).post('/api/auth/embed/token').send({
+      code: 'authcode',
+      code_verifier: 'verifier-xyz',
+      redirect_uri: 'https://chat.cat-herding.net/embed/callback.html',
+      client_id: 'client-foo',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBe('abc.def.ghi');
+    expect(res.body.refresh_token).toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toMatch(/\/oauth\/token$/);
+    expect((init as RequestInit).method).toBe('POST');
+    const body = String((init as RequestInit).body || '');
+    expect(body).toContain('grant_type=authorization_code');
+    expect(body).toContain('code=authcode');
+    expect(body).toContain('code_verifier=verifier-xyz');
+    expect(body).toContain('client_id=client-foo');
+  });
+
+  it('propagates upstream error status and body', async () => {
+    fetchMock.mockResolvedValue(
+      mkResponse(400, {
+        error: 'invalid_grant',
+        error_description: 'Code expired',
+      }),
+    );
+
+    const res = await request(app).post('/api/auth/embed/token').send({
+      code: 'bad',
+      code_verifier: 'v',
+      redirect_uri: 'https://chat.cat-herding.net/embed/callback.html',
+      client_id: 'client-foo',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_grant');
+    expect(res.body.error_description).toBe('Code expired');
+  });
+
+  it('returns 502 when the upstream is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const res = await request(app).post('/api/auth/embed/token').send({
+      code: 'x',
+      code_verifier: 'v',
+      redirect_uri: 'https://chat.cat-herding.net/embed/callback.html',
+      client_id: 'client-foo',
+    });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('bad_gateway');
+  });
+});

--- a/backend/src/routes/embedAuth.ts
+++ b/backend/src/routes/embedAuth.ts
@@ -83,8 +83,12 @@ router.post('/token', exchangeLimiter, async (req: Request, res: Response) => {
     try {
       payload = JSON.parse(text);
     } catch {
+      // Avoid logging `tokenUrl` or response bodies here — CodeQL flags
+      // clear-text logging of values derived from the auth server and the
+      // issuer URL is considered sensitive metadata. Status code is enough
+      // to triage.
       logger.warn(
-        { status: upstream.status, tokenUrl },
+        { status: upstream.status },
         'Embed auth upstream returned non-JSON',
       );
       res.status(502).json({
@@ -95,10 +99,10 @@ router.post('/token', exchangeLimiter, async (req: Request, res: Response) => {
     }
 
     if (!upstream.ok) {
-      logger.info(
-        { status: upstream.status, error: payload.error },
-        'Embed auth upstream error',
-      );
+      // Intentionally log only the upstream status code. `payload` is
+      // derived from the auth server and can contain data CodeQL
+      // considers sensitive; forward it to the browser but do not log it.
+      logger.info({ status: upstream.status }, 'Embed auth upstream error');
       res.status(upstream.status).json(payload);
       return;
     }

--- a/backend/src/routes/embedAuth.ts
+++ b/backend/src/routes/embedAuth.ts
@@ -1,0 +1,123 @@
+import { Router, Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
+import { logger } from '../logger';
+
+/**
+ * Token-exchange proxy for the embeddable chat widget.
+ *
+ * The public roauth2 server accepts PKCE-only token requests (no client
+ * secret required), but does not set CORS headers permitting the chat
+ * origin to POST directly from the browser. This endpoint sits same-origin
+ * with the widget and forwards the code+verifier to roauth2 so the browser
+ * never has to cross into the auth server.
+ *
+ * Security posture:
+ *   - Public (no authenticateToken) — the user IS in the middle of signing in.
+ *   - Tight rate limit per IP to discourage spray attacks.
+ *   - `refresh_token` is stripped before returning to the browser; short-
+ *     lived access tokens limit the blast radius if the bundle is XSS'd.
+ */
+
+const router = Router();
+
+const EMBED_OAUTH2_ISSUER =
+  process.env.EMBED_OAUTH2_ISSUER || 'https://roauth2.cat-herding.net';
+
+const exchangeLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logger.warn({ ip: req.ip }, 'Embed auth exchange rate limit exceeded');
+    res.status(429).json({
+      error: 'too_many_requests',
+      error_description:
+        'Too many sign-in attempts from this IP. Please try again later.',
+    });
+  },
+});
+
+interface ExchangeBody {
+  code?: string;
+  code_verifier?: string;
+  redirect_uri?: string;
+  client_id?: string;
+}
+
+router.post('/token', exchangeLimiter, async (req: Request, res: Response) => {
+  const { code, code_verifier, redirect_uri, client_id } =
+    (req.body as ExchangeBody) || {};
+
+  if (!code || !code_verifier || !redirect_uri || !client_id) {
+    res.status(400).json({
+      error: 'invalid_request',
+      error_description:
+        'code, code_verifier, redirect_uri, and client_id are required',
+    });
+    return;
+  }
+
+  const tokenUrl = `${EMBED_OAUTH2_ISSUER.replace(/\/$/, '')}/oauth/token`;
+
+  const form = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    code_verifier,
+    redirect_uri,
+    client_id,
+  });
+
+  try {
+    const upstream = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: form.toString(),
+    });
+
+    const text = await upstream.text();
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      logger.warn(
+        { status: upstream.status, tokenUrl },
+        'Embed auth upstream returned non-JSON',
+      );
+      res.status(502).json({
+        error: 'bad_gateway',
+        error_description: 'Upstream authorization server returned non-JSON',
+      });
+      return;
+    }
+
+    if (!upstream.ok) {
+      logger.info(
+        { status: upstream.status, error: payload.error },
+        'Embed auth upstream error',
+      );
+      res.status(upstream.status).json(payload);
+      return;
+    }
+
+    // Strip long-lived refresh_token before handing back to the browser to
+    // limit XSS blast radius. Users can sign in again when the access token
+    // expires.
+    if ('refresh_token' in payload) {
+      delete payload.refresh_token;
+    }
+
+    res.json(payload);
+  } catch (err) {
+    logger.error({ err }, 'Embed auth exchange failed');
+    res.status(502).json({
+      error: 'bad_gateway',
+      error_description: 'Upstream authorization server unreachable',
+    });
+  }
+});
+
+export default router;

--- a/embed/README.md
+++ b/embed/README.md
@@ -45,8 +45,70 @@ If the host page enforces a CSP, allow:
 | `placeholder`    | `string`                                                       | `'Ask me anything…'`  | Text for the input placeholder.                                                                                          |
 | `welcomeMessage` | `string \| null`                                               | short welcome         | First bubble shown. Pass `null` to omit.                                                                                 |
 | `footerHtml`     | `string \| null`                                               | link to repo          | HTML rendered in the footer. Pass `null` to omit.                                                                        |
+| `auth`           | `AuthOptions`                                                  | _none_ (anon)         | OAuth2 + PKCE sign-in config. When set, the widget renders a Sign-in button and forwards the access token on the socket. |
+| `signInLabel`    | `string`                                                       | `'Sign in to chat'`   | Label on the Sign-in button when `auth` is set.                                                                          |
 
-`CatHerdingChat.init()` returns the `ChatWidget` instance. The widget also exposes `open()`, `close()`, `toggle()`, and `destroy()` methods.
+`CatHerdingChat.init()` returns the `ChatWidget` instance. The widget also exposes `open()`, `close()`, `toggle()`, `destroy()`, `isAuthenticated()`, and `signOut()` methods.
+
+## OAuth2 sign-in (optional)
+
+The widget ships a built-in PKCE flow for gated deployments. Portfolio pages stay static — all auth code lives inside the widget.
+
+```html
+<script src="https://chat.cat-herding.net/embed/cat-herding-chat.js" defer></script>
+<script>
+  window.addEventListener('load', () => {
+    window.CatHerdingChat.init({
+      apiUrl: 'https://chat.cat-herding.net',
+      mode: 'lean',
+      auth: {
+        type: 'oauth2',
+        issuer: 'https://roauth2.cat-herding.net',
+        clientId: '<your-registered-public-client-id>',
+        scopes: 'openid profile email',
+        tokenStorage: 'session', // 'memory' | 'session' | 'local'
+      },
+    });
+  });
+</script>
+```
+
+### How the flow works
+
+1. Panel opens → widget shows a **Sign in to chat** button (input row is hidden).
+2. Click → popup opens at the issuer's `authorization_endpoint` with a PKCE challenge + random `state`.
+3. User signs in at the auth server → redirect to `https://chat.cat-herding.net/embed/callback.html?code=…&state=…`.
+4. Callback page `postMessage`s the `{code, state}` back to the opener and closes itself.
+5. Widget verifies `state`, POSTs `{code, code_verifier, …}` to `<apiUrl>/api/auth/embed/token` (a same-origin proxy; avoids the roauth2 CORS gap).
+6. Proxy forwards to `/oauth/token` and strips `refresh_token` before returning — short-lived access tokens only.
+7. Widget forwards `access_token` on the Socket.IO handshake (`socket.auth.token`).
+
+### `AuthOptions`
+
+| Field          | Type                               | Default                         | Notes                                                                                   |
+| -------------- | ---------------------------------- | ------------------------------- | --------------------------------------------------------------------------------------- |
+| `type`         | `'oauth2'`                         | required                        | Discriminator.                                                                          |
+| `issuer`       | `string`                           | required                        | OIDC issuer URL. Discovery fetched from `<issuer>/.well-known/openid-configuration`.    |
+| `clientId`     | `string`                           | required                        | Public client id. Must be registered with a redirect of `<apiUrl>/embed/callback.html`. |
+| `scopes`       | `string`                           | `'openid profile email'`        | Space-separated scopes.                                                                 |
+| `redirectUri`  | `string`                           | `<apiUrl>/embed/callback.html`  | Override only if you need a non-standard callback.                                      |
+| `tokenStorage` | `'memory' \| 'session' \| 'local'` | `'session'`                     | Where the access token is persisted.                                                    |
+| `exchangeUrl`  | `string`                           | `<apiUrl>/api/auth/embed/token` | Override the same-origin token-exchange proxy path.                                     |
+
+### Registering a public PKCE client
+
+Point the client registration at the widget-owned callback URL so you don't have to re-register per embed host:
+
+- `redirect_uris`: `https://chat.cat-herding.net/embed/callback.html` (prod), optionally `http://localhost:5199/embed/callback.html` + `http://localhost:5001/embed/callback.html` for dev.
+- `grant_types`: `authorization_code` (optionally `refresh_token`).
+- `scope`: `openid profile email`.
+
+### Security notes
+
+- The widget never ships a client secret. PKCE + server-side token exchange proxy means the public JS bundle holds only the client id.
+- `refresh_token` is stripped before it reaches the browser. Users sign in again when the access token expires.
+- The token-exchange proxy is rate-limited per IP (30 / 5 min).
+- `sessionStorage` is the default — cleared on tab close and scoped to the chat origin.
 
 ## Isolation
 

--- a/embed/assets/embed/callback.html
+++ b/embed/assets/embed/callback.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Signing you in…</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #f9fafb;
+        color: #111827;
+      }
+      .card {
+        text-align: center;
+        max-width: 360px;
+        padding: 24px;
+      }
+      .spinner {
+        width: 28px;
+        height: 28px;
+        border: 3px solid #e5e7eb;
+        border-top-color: #4f46e5;
+        border-radius: 50%;
+        margin: 0 auto 14px;
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      h1 {
+        font-size: 16px;
+        margin: 0 0 6px;
+      }
+      p {
+        font-size: 13px;
+        color: #6b7280;
+        margin: 0;
+      }
+      .err {
+        color: #b91c1c;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <div class="spinner" id="spin" aria-hidden="true"></div>
+      <h1 id="title">Signing you in…</h1>
+      <p id="msg">This window will close automatically.</p>
+    </div>
+    <script>
+      (function () {
+        var title = document.getElementById('title');
+        var msg = document.getElementById('msg');
+        var spin = document.getElementById('spin');
+
+        function render(text, errorText) {
+          title.textContent = text;
+          if (errorText) {
+            msg.textContent = errorText;
+            msg.className = 'err';
+            spin.style.display = 'none';
+          }
+        }
+
+        function parseParams(search) {
+          var out = {};
+          var qs = (search || '').replace(/^\?/, '');
+          if (!qs) return out;
+          qs.split('&').forEach(function (pair) {
+            if (!pair) return;
+            var idx = pair.indexOf('=');
+            var k = decodeURIComponent(
+              (idx >= 0 ? pair.slice(0, idx) : pair).replace(/\+/g, ' '),
+            );
+            var v = decodeURIComponent(
+              (idx >= 0 ? pair.slice(idx + 1) : '').replace(/\+/g, ' '),
+            );
+            out[k] = v;
+          });
+          return out;
+        }
+
+        var params = parseParams(window.location.search);
+        var payload = {
+          source: 'cat-herding-chat-oauth',
+          code: params.code || null,
+          state: params.state || null,
+          error: params.error || null,
+          error_description: params.error_description || null,
+        };
+
+        var targetOrigin = window.location.origin;
+
+        try {
+          if (window.opener && !window.opener.closed) {
+            window.opener.postMessage(payload, targetOrigin);
+            render(
+              payload.error ? 'Sign-in failed' : 'Signed in',
+              payload.error,
+            );
+            setTimeout(
+              function () {
+                window.close();
+              },
+              payload.error ? 2000 : 150,
+            );
+          } else {
+            render('Cannot complete sign-in', 'Missing opener window.');
+          }
+        } catch (e) {
+          render('Sign-in error', String(e && e.message) || 'Unexpected error');
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/embed/demo/index.html
+++ b/embed/demo/index.html
@@ -39,7 +39,12 @@
     window.CatHerdingChat.init({
       apiUrl: 'https://chat.cat-herding.net',
       title: 'Ask about my portfolio',
-      mode: 'lean'
+      mode: 'lean',
+      auth: {
+        type: 'oauth2',
+        issuer: 'https://roauth2.cat-herding.net',
+        clientId: '&lt;your-registered-client-id&gt;'
+      }
     });
   });
 &lt;/script&gt;</code></pre>
@@ -53,6 +58,12 @@
           title: 'Portfolio chat (dev)',
           subtitle: 'Local backend',
           mode: 'lean',
+          // Uncomment to exercise the OAuth2 sign-in gate locally.
+          // auth: {
+          //   type: 'oauth2',
+          //   issuer: 'https://roauth2.cat-herding.net',
+          //   clientId: 'client_a3419797-efbc-4c87-95f4-f88c74e0c4ef',
+          // },
         });
       });
     </script>

--- a/embed/src/auth.ts
+++ b/embed/src/auth.ts
@@ -1,0 +1,398 @@
+/**
+ * OAuth2 + PKCE sign-in flow for the embeddable chat widget.
+ *
+ * Flow:
+ *   1. Widget → fetch discovery doc from `<issuer>/.well-known/openid-configuration`.
+ *   2. Widget → generate PKCE verifier + challenge and a random `state`.
+ *   3. Widget → open popup to `authorization_endpoint` with PKCE params.
+ *   4. User signs in on the auth server; auth server redirects popup to
+ *      `<apiUrl>/embed/callback.html?code=…&state=…`.
+ *   5. callback.html → `postMessage({code, state}, origin)` back to opener,
+ *      then closes itself.
+ *   6. Widget verifies `state`, POSTs `{code, code_verifier, ...}` to
+ *      `<apiUrl>/api/auth/embed/token` (same-origin proxy, bypasses the
+ *      roauth2 CORS gap + strips refresh_token server-side).
+ *   7. Widget stores access_token per `tokenStorage` and emits `onChange`.
+ *
+ * We never ship a client secret. The registered roauth2 client accepts
+ * PKCE-only token exchanges; the proxy forwards without any secret too.
+ */
+
+export type TokenStorageMode = 'memory' | 'session' | 'local';
+
+export interface AuthOptions {
+  type: 'oauth2';
+  /** Base issuer URL, e.g. `https://roauth2.cat-herding.net`. */
+  issuer: string;
+  /** OAuth2 public client id registered with the issuer. */
+  clientId: string;
+  /** Space-separated OAuth2 scopes. Default: `openid profile email`. */
+  scopes?: string;
+  /**
+   * Full redirect_uri. Must be one of the client's registered URIs. If
+   * omitted, defaults to `<widget.apiUrl>/embed/callback.html`.
+   */
+  redirectUri?: string;
+  /**
+   * Where to persist the access_token.
+   *   - `memory`  — in-memory only (safest, requires sign-in every page load)
+   *   - `session` — sessionStorage (default, survives same-tab nav/reload)
+   *   - `local`   — localStorage (cross-tab, biggest XSS surface)
+   */
+  tokenStorage?: TokenStorageMode;
+  /**
+   * Override the same-origin token-exchange proxy path. Defaults to
+   * `<widget.apiUrl>/api/auth/embed/token`.
+   */
+  exchangeUrl?: string;
+}
+
+export interface AuthSession {
+  accessToken: string;
+  idToken?: string;
+  expiresAt: number;
+  claims?: Record<string, unknown>;
+}
+
+export type AuthListener = (session: AuthSession | null) => void;
+
+interface DiscoveryDoc {
+  authorization_endpoint: string;
+  token_endpoint: string;
+  end_session_endpoint?: string;
+}
+
+interface StoredState {
+  state: string;
+  codeVerifier: string;
+  redirectUri: string;
+  createdAt: number;
+}
+
+const STORAGE_KEY_TOKEN = 'cat-herding-chat.token';
+const STORAGE_KEY_PENDING = 'cat-herding-chat.pkce';
+const POSTMESSAGE_SOURCE = 'cat-herding-chat-oauth';
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function randomUrlSafe(byteLen: number): string {
+  const arr = new Uint8Array(byteLen);
+  crypto.getRandomValues(arr);
+  return base64UrlEncode(arr);
+}
+
+async function sha256(input: string): Promise<Uint8Array> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return new Uint8Array(digest);
+}
+
+function decodeJwtClaims(jwt: string): Record<string, unknown> | undefined {
+  const parts = jwt.split('.');
+  if (parts.length < 2) return undefined;
+  try {
+    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = payload + '==='.slice((payload.length + 3) % 4);
+    return JSON.parse(atob(padded)) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+export class AuthManager {
+  private opts: Required<Pick<AuthOptions, 'scopes' | 'tokenStorage'>> &
+    AuthOptions;
+  private apiUrl: string;
+  private discoveryPromise: Promise<DiscoveryDoc> | null = null;
+  private session: AuthSession | null = null;
+  private listeners = new Set<AuthListener>();
+  private popup: Window | null = null;
+  private messageHandler: ((e: MessageEvent) => void) | null = null;
+
+  constructor(apiUrl: string, opts: AuthOptions) {
+    this.apiUrl = apiUrl.replace(/\/$/, '');
+    this.opts = {
+      scopes: 'openid profile email',
+      tokenStorage: 'session',
+      ...opts,
+    };
+    this.session = this.loadPersistedSession();
+  }
+
+  onChange(cb: AuthListener): () => void {
+    this.listeners.add(cb);
+    return () => this.listeners.delete(cb);
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.session && Date.now() < this.session.expiresAt;
+  }
+
+  getSession(): AuthSession | null {
+    return this.isAuthenticated() ? this.session : null;
+  }
+
+  async signIn(): Promise<AuthSession> {
+    const disc = await this.getDiscovery();
+    const state = randomUrlSafe(16);
+    const codeVerifier = randomUrlSafe(64);
+    const codeChallenge = base64UrlEncode(await sha256(codeVerifier));
+    const redirectUri =
+      this.opts.redirectUri || `${this.apiUrl}/embed/callback.html`;
+
+    const pending: StoredState = {
+      state,
+      codeVerifier,
+      redirectUri,
+      createdAt: Date.now(),
+    };
+    sessionStorage.setItem(STORAGE_KEY_PENDING, JSON.stringify(pending));
+
+    const url = new URL(disc.authorization_endpoint);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', this.opts.clientId);
+    url.searchParams.set('redirect_uri', redirectUri);
+    url.searchParams.set('scope', this.opts.scopes);
+    url.searchParams.set('state', state);
+    url.searchParams.set('code_challenge', codeChallenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+
+    return new Promise<AuthSession>((resolve, reject) => {
+      this.popup = this.openPopup(url.toString());
+      if (!this.popup) {
+        reject(new Error('Popup blocked. Allow popups and try again.'));
+        return;
+      }
+
+      let popupWatcher: ReturnType<typeof setInterval> | null = null;
+      // Signals that the popup has delivered its postMessage — flips to
+      // true once we start handling a valid response. Prevents the
+      // popup-closed watcher from racing with the async token exchange
+      // when the callback window self-closes mid-exchange.
+      let handlingResponse = false;
+
+      const stopWatcher = (): void => {
+        if (popupWatcher) {
+          clearInterval(popupWatcher);
+          popupWatcher = null;
+        }
+      };
+
+      const cleanup = (): void => {
+        if (this.messageHandler) {
+          window.removeEventListener('message', this.messageHandler);
+          this.messageHandler = null;
+        }
+        stopWatcher();
+      };
+
+      this.messageHandler = async (evt: MessageEvent) => {
+        if (evt.origin !== window.location.origin && evt.origin !== this.apiUrl)
+          return;
+        const data = evt.data as
+          | {
+              source?: string;
+              code?: string;
+              state?: string;
+              error?: string;
+              error_description?: string;
+            }
+          | undefined;
+        if (!data || data.source !== POSTMESSAGE_SOURCE) return;
+
+        // Stop the popup-closed watcher immediately on any recognized
+        // response — the popup is about to self-close and we don't want
+        // its natural closure to reject this promise while the token
+        // exchange is still in flight.
+        handlingResponse = true;
+        stopWatcher();
+
+        const stored = this.readPending();
+        if (!stored) {
+          cleanup();
+          reject(new Error('Sign-in state expired. Please try again.'));
+          return;
+        }
+
+        if (data.error) {
+          cleanup();
+          sessionStorage.removeItem(STORAGE_KEY_PENDING);
+          reject(
+            new Error(
+              data.error_description || data.error || 'Authorization failed',
+            ),
+          );
+          return;
+        }
+
+        if (!data.code || data.state !== stored.state) {
+          cleanup();
+          sessionStorage.removeItem(STORAGE_KEY_PENDING);
+          reject(new Error('Invalid sign-in response (state mismatch).'));
+          return;
+        }
+
+        sessionStorage.removeItem(STORAGE_KEY_PENDING);
+        try {
+          const session = await this.exchangeCode(
+            data.code,
+            stored.codeVerifier,
+            stored.redirectUri,
+          );
+          cleanup();
+          this.setSession(session);
+          resolve(session);
+        } catch (err) {
+          cleanup();
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      };
+
+      window.addEventListener('message', this.messageHandler);
+
+      popupWatcher = setInterval(() => {
+        if (handlingResponse) return;
+        if (this.popup && this.popup.closed) {
+          cleanup();
+          reject(new Error('Sign-in window was closed.'));
+        }
+      }, 500);
+    });
+  }
+
+  signOut(): void {
+    this.setSession(null);
+  }
+
+  private setSession(session: AuthSession | null): void {
+    this.session = session;
+    this.persistSession(session);
+    for (const listener of this.listeners) listener(session);
+  }
+
+  private async exchangeCode(
+    code: string,
+    codeVerifier: string,
+    redirectUri: string,
+  ): Promise<AuthSession> {
+    const exchangeUrl =
+      this.opts.exchangeUrl || `${this.apiUrl}/api/auth/embed/token`;
+
+    const resp = await fetch(exchangeUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        code,
+        code_verifier: codeVerifier,
+        redirect_uri: redirectUri,
+        client_id: this.opts.clientId,
+      }),
+    });
+
+    const json = (await resp.json().catch(() => ({}))) as {
+      access_token?: string;
+      id_token?: string;
+      expires_in?: number;
+      error?: string;
+      error_description?: string;
+    };
+
+    if (!resp.ok || !json.access_token) {
+      throw new Error(
+        json.error_description || json.error || 'Token exchange failed',
+      );
+    }
+
+    return {
+      accessToken: json.access_token,
+      idToken: json.id_token,
+      expiresAt: Date.now() + (json.expires_in ?? 3600) * 1000,
+      claims: json.id_token ? decodeJwtClaims(json.id_token) : undefined,
+    };
+  }
+
+  private async getDiscovery(): Promise<DiscoveryDoc> {
+    if (!this.discoveryPromise) {
+      const url =
+        this.opts.issuer.replace(/\/$/, '') +
+        '/.well-known/openid-configuration';
+      this.discoveryPromise = fetch(url, {
+        credentials: 'omit',
+        headers: { Accept: 'application/json' },
+      }).then(async r => {
+        if (!r.ok) throw new Error(`OIDC discovery failed: HTTP ${r.status}`);
+        return (await r.json()) as DiscoveryDoc;
+      });
+    }
+    return this.discoveryPromise;
+  }
+
+  private openPopup(url: string): Window | null {
+    const w = 520;
+    const h = 680;
+    const left = Math.max(0, (window.screen.width - w) / 2);
+    const top = Math.max(0, (window.screen.height - h) / 2);
+    const features = [
+      `width=${w}`,
+      `height=${h}`,
+      `left=${left}`,
+      `top=${top}`,
+      'resizable=yes',
+      'scrollbars=yes',
+      'status=no',
+      'menubar=no',
+      'toolbar=no',
+    ].join(',');
+    return window.open(url, 'cat-herding-chat-oauth', features);
+  }
+
+  private readPending(): StoredState | null {
+    const raw = sessionStorage.getItem(STORAGE_KEY_PENDING);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as StoredState;
+      // Expire pending requests after 10 minutes.
+      if (Date.now() - parsed.createdAt > 10 * 60 * 1000) return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  private persistSession(session: AuthSession | null): void {
+    if (this.opts.tokenStorage === 'memory') return;
+    const store =
+      this.opts.tokenStorage === 'local' ? localStorage : sessionStorage;
+    if (!session) {
+      store.removeItem(STORAGE_KEY_TOKEN);
+      return;
+    }
+    store.setItem(STORAGE_KEY_TOKEN, JSON.stringify(session));
+  }
+
+  private loadPersistedSession(): AuthSession | null {
+    if (this.opts.tokenStorage === 'memory') return null;
+    const store =
+      this.opts.tokenStorage === 'local' ? localStorage : sessionStorage;
+    const raw = store.getItem(STORAGE_KEY_TOKEN);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as AuthSession;
+      if (!parsed.accessToken || Date.now() >= parsed.expiresAt) {
+        store.removeItem(STORAGE_KEY_TOKEN);
+        return null;
+      }
+      return parsed;
+    } catch {
+      store.removeItem(STORAGE_KEY_TOKEN);
+      return null;
+    }
+  }
+}

--- a/embed/src/index.ts
+++ b/embed/src/index.ts
@@ -29,3 +29,4 @@ if (typeof window !== 'undefined') {
 
 export { ChatWidget, api };
 export type { ChatWidgetOptions } from './widget';
+export type { AuthOptions, AuthSession, TokenStorageMode } from './auth';

--- a/embed/src/styles.ts
+++ b/embed/src/styles.ts
@@ -179,6 +179,40 @@ export const widgetCss = /* css */ `
   40% { transform: scale(1); opacity: 1; }
 }
 
+.signin-gate {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  background: #fff;
+  border-top: 1px solid #e5e7eb;
+  align-items: stretch;
+}
+.signin-gate .signin-btn {
+  border: none;
+  background: var(--ch-accent, #4f46e5);
+  color: #fff;
+  padding: 10px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  font-family: inherit;
+}
+.signin-gate .signin-btn:hover {
+  filter: brightness(1.05);
+}
+.signin-gate .signin-btn:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+.signin-gate .signin-hint {
+  font-size: 12px;
+  color: #6b7280;
+  text-align: center;
+  min-height: 1em;
+}
+
 .input-row {
   display: flex;
   gap: 8px;

--- a/embed/src/widget.ts
+++ b/embed/src/widget.ts
@@ -1,6 +1,7 @@
 import { io, Socket } from 'socket.io-client';
 import { widgetCss } from './styles';
 import { chatIcon, closeIcon } from './icons';
+import { AuthManager, AuthOptions, AuthSession } from './auth';
 
 export type WidgetPosition =
   | 'bottom-right'
@@ -19,6 +20,17 @@ export interface ChatWidgetOptions {
   placeholder?: string;
   footerHtml?: string | null;
   welcomeMessage?: string | null;
+  /**
+   * Optional OAuth2 + PKCE sign-in config. When set, the widget renders a
+   * Sign-in gate instead of connecting anonymously and forwards the access
+   * token on the Socket.IO handshake.
+   */
+  auth?: AuthOptions;
+  /**
+   * Label on the Sign-in button when auth gating is active.
+   * Default: `Sign in to chat`.
+   */
+  signInLabel?: string;
 }
 
 interface Attachment {
@@ -56,8 +68,11 @@ const POSITION_CLASS: Record<WidgetPosition, string> = {
 };
 
 const DEFAULTS: Required<
-  Omit<ChatWidgetOptions, 'apiUrl' | 'footerHtml' | 'welcomeMessage'>
-> & { footerHtml: string | null; welcomeMessage: string | null } = {
+  Omit<ChatWidgetOptions, 'apiUrl' | 'footerHtml' | 'welcomeMessage' | 'auth'>
+> & {
+  footerHtml: string | null;
+  welcomeMessage: string | null;
+} = {
   title: 'Cat-Herding Chat',
   subtitle: 'AI portfolio demo',
   position: 'bottom-right',
@@ -65,6 +80,7 @@ const DEFAULTS: Required<
   mode: 'lean',
   openOnLoad: false,
   placeholder: 'Ask me anything…',
+  signInLabel: 'Sign in to chat',
   footerHtml:
     'Demo powered by <a href="https://github.com/ianlintner/Example-React-AI-Chat-App" target="_blank" rel="noopener">cat-herding</a>',
   welcomeMessage:
@@ -80,16 +96,33 @@ export class ChatWidget {
   private inputEl!: HTMLInputElement;
   private sendBtn!: HTMLButtonElement;
   private statusEl!: HTMLDivElement;
+  private signInEl: HTMLDivElement | null = null;
+  private inputRowEl: HTMLFormElement | null = null;
   private typingEl: HTMLDivElement | null = null;
   private socket: Socket | null = null;
   private conversationId: string | null = null;
   private streamingMessages = new Map<string, HTMLDivElement>();
+  private auth: AuthManager | null = null;
 
   constructor(opts: ChatWidgetOptions) {
     if (!opts || !opts.apiUrl) {
       throw new Error('CatHerdingChat: apiUrl is required');
     }
     this.opts = { ...DEFAULTS, ...opts };
+    if (this.opts.auth) {
+      this.auth = new AuthManager(this.opts.apiUrl, this.opts.auth);
+      this.auth.onChange(session => this.onAuthChange(session));
+    }
+  }
+
+  /** Whether a signed-in OAuth2 session is active. */
+  isAuthenticated(): boolean {
+    return !!this.auth?.isAuthenticated();
+  }
+
+  /** Clear the local session and reset the widget to the Sign-in state. */
+  signOut(): void {
+    this.auth?.signOut();
   }
 
   mount(target: HTMLElement = document.body): void {
@@ -123,8 +156,11 @@ export class ChatWidget {
 
   open(): void {
     this.root.classList.add('open');
-    this.ensureConnected();
-    setTimeout(() => this.inputEl?.focus(), 50);
+    this.syncAuthGate();
+    if (!this.auth || this.auth.isAuthenticated()) {
+      this.ensureConnected();
+      setTimeout(() => this.inputEl?.focus(), 50);
+    }
   }
 
   close(): void {
@@ -187,6 +223,24 @@ export class ChatWidget {
       });
     }
 
+    // Sign-in gate (only rendered when auth config is supplied). Replaces
+    // the input row until the user signs in.
+    if (this.auth) {
+      const gate = document.createElement('div');
+      gate.className = 'signin-gate';
+      gate.innerHTML = `
+        <button class="signin-btn" type="button"></button>
+        <div class="signin-hint"></div>
+      `;
+      const btn = gate.querySelector('.signin-btn') as HTMLButtonElement;
+      btn.textContent = this.opts.signInLabel;
+      btn.addEventListener('click', () => {
+        this.handleSignIn();
+      });
+      this.signInEl = gate;
+      panel.appendChild(gate);
+    }
+
     const inputRow = document.createElement('form');
     inputRow.className = 'input-row';
     inputRow.innerHTML = `
@@ -204,6 +258,7 @@ export class ChatWidget {
       e.preventDefault();
       this.handleSend();
     });
+    this.inputRowEl = inputRow;
     panel.appendChild(inputRow);
 
     if (this.opts.footerHtml) {
@@ -212,6 +267,8 @@ export class ChatWidget {
       footer.innerHTML = this.opts.footerHtml;
       panel.appendChild(footer);
     }
+
+    this.syncAuthGate();
   }
 
   private setStatus(
@@ -230,6 +287,10 @@ export class ChatWidget {
     const query: Record<string, string> = {};
     if (this.opts.mode === 'lean') query.mode = 'lean';
 
+    const session = this.auth?.getSession();
+    const authPayload: { token?: string } = {};
+    if (session?.accessToken) authPayload.token = session.accessToken;
+
     this.setStatus('connecting', 'Connecting…');
 
     this.socket = io(this.opts.apiUrl, {
@@ -237,6 +298,7 @@ export class ChatWidget {
       transports: ['websocket', 'polling'],
       withCredentials: true,
       query,
+      auth: authPayload,
       reconnectionAttempts: 5,
       timeout: 15000,
     });
@@ -323,6 +385,55 @@ export class ChatWidget {
         });
       },
     );
+  }
+
+  private async handleSignIn(): Promise<void> {
+    if (!this.auth || !this.signInEl) return;
+    const btn = this.signInEl.querySelector('.signin-btn') as HTMLButtonElement;
+    const hint = this.signInEl.querySelector('.signin-hint') as HTMLElement;
+    btn.disabled = true;
+    hint.textContent = 'Opening sign-in window…';
+    try {
+      await this.auth.signIn();
+      hint.textContent = '';
+    } catch (err) {
+      hint.textContent =
+        err instanceof Error
+          ? err.message
+          : 'Sign-in failed. Please try again.';
+      btn.disabled = false;
+    }
+  }
+
+  private onAuthChange(session: AuthSession | null): void {
+    this.syncAuthGate();
+    if (session) {
+      // Tear down any anon socket; reconnect with the token on handshake.
+      if (this.socket) {
+        this.socket.disconnect();
+        this.socket = null;
+      }
+      this.ensureConnected();
+      setTimeout(() => this.inputEl?.focus(), 50);
+    } else if (this.socket) {
+      this.socket.disconnect();
+      this.socket = null;
+      this.setStatus('error', 'Signed out');
+    }
+  }
+
+  private syncAuthGate(): void {
+    if (!this.auth) return;
+    const authed = this.auth.isAuthenticated();
+    if (this.signInEl) this.signInEl.style.display = authed ? 'none' : 'flex';
+    if (this.inputRowEl)
+      this.inputRowEl.style.display = authed ? 'flex' : 'none';
+    if (this.signInEl && !authed) {
+      const btn = this.signInEl.querySelector(
+        '.signin-btn',
+      ) as HTMLButtonElement;
+      if (btn) btn.disabled = false;
+    }
   }
 
   private handleSend(): void {

--- a/embed/vite.config.ts
+++ b/embed/vite.config.ts
@@ -12,7 +12,11 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'CatHerdingChat',
       formats: ['iife'],
-      fileName: () => 'cat-herding-chat.js',
+      // Emit under `embed/` so the prod deploy (`dist/**` copied to the
+      // backend's `public/` dir) serves both the JS bundle and
+      // `callback.html` from `/embed/...`. Matches the OAuth2 client's
+      // registered redirect URIs.
+      fileName: () => 'embed/cat-herding-chat.js',
     },
     rollupOptions: {
       output: {
@@ -21,7 +25,10 @@ export default defineConfig({
       },
     },
   },
-  publicDir: false,
+  // `assets/` holds static files (callback.html) that must ship alongside the
+  // JS bundle. `demo/` is dev-only and excluded from the build via its own
+  // path (Vite's publicDir copies everything under it verbatim).
+  publicDir: 'assets',
   server: {
     port: 5199,
     open: '/demo/index.html',


### PR DESCRIPTION
## Summary

- Adds optional OAuth2 + PKCE sign-in to the embeddable chat widget. Portfolio pages stay static — all auth plumbing lives inside the widget bundle.
- Widget does the PKCE dance client-side and POSTs `{code, code_verifier, redirect_uri, client_id}` to a new same-origin backend proxy (`/api/auth/embed/token`) that forwards to the issuer's `/oauth/token`. The proxy strips `refresh_token` before returning to the browser.
- Adds `isAuthenticated()`, `signOut()`, `onChange` on the widget instance, plus a configurable Sign-in button gate that replaces the input row until a session is active.
- `tokenStorage` option (`'memory' | 'session' | 'local'`) — defaults to `sessionStorage`.
- Build layout moved under `dist/embed/` so both `cat-herding-chat.js` and `callback.html` ship at `/embed/*` in prod **and** in Vite dev — matches the registered redirect URIs in both environments.
- Dockerfile copies the embed build into `backend/public/` preserving the `embed/` subdir.

## Why a backend proxy

Probe against roauth2 showed the token endpoint accepts PKCE-only exchanges (no client secret required) but **does not set CORS headers for the chat origin**, so the browser can't POST to it directly. The backend proxy sits same-origin with the widget, forwards the PKCE exchange, and strips `refresh_token` for XSS hygiene. No client secret is ever shipped in the public JS bundle.

## Host-page usage

```html
<script src="https://chat.cat-herding.net/embed/cat-herding-chat.js" defer></script>
<script>
  window.addEventListener('load', () => {
    window.CatHerdingChat.init({
      apiUrl: 'https://chat.cat-herding.net',
      mode: 'lean',
      auth: {
        type: 'oauth2',
        issuer: 'https://roauth2.cat-herding.net',
        clientId: '<your-registered-public-client-id>',
        scopes: 'openid profile email',
      },
    });
  });
</script>
```

## OAuth2 client

A `cat-herding-chat-embed` client is already registered on roauth2 with `redirect_uris` covering:
- `https://chat.cat-herding.net/embed/callback.html` (prod)
- `http://localhost:5199/embed/callback.html` (Vite dev)
- `http://localhost:5001/embed/callback.html` (backend dev)

The `client_id` is safe to inline in the host page snippet. No client secret is used anywhere in the flow.

## Tests

- Backend: four new unit tests on the token-exchange route covering happy path, missing-field 400, upstream error passthrough, and upstream-unreachable 502. `jest.fn()` mocks global `fetch`.
- Backend: socket regression still green (26/26, including the lean-mode test from the prior PR).
- Embed: `tsc --noEmit` clean, `vite build` clean — bundle grew 17.3 → **19.6 KB gzipped**.
- **Not runtime-verified in a browser** — this sandbox blocks all TCP binds, so I couldn't run `vite dev` + `backend dev` + a signed-in popup locally. Request a full manual smoke test against dev or staging before relying on this in prod. Specifically: popup opens, state round-trips, proxy returns a token, socket reconnects with `socket.auth.token`, streaming works as signed-in user.

## Test plan

- [x] `embed`: `tsc --noEmit` + `vite build` clean; `dist/embed/{cat-herding-chat.js,callback.html}` present
- [x] `backend`: `npm run typecheck` + `npm run lint` clean
- [x] New embed-auth proxy unit tests + socket regression pass locally
- [ ] Local smoke test with backend + embed dev servers: click Sign in → popup → approve → callback closes → widget shows input row → send a message streams back
- [ ] Post-deploy smoke test against `chat.cat-herding.net` from `portfolio.cat-herding.net` (same snippet as above)
- [ ] Rotate the roauth2 client secret that was returned at registration time (not used anywhere in this PR, but exists — follow-up hygiene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)