### PR TITLE
fix(k8s): allow anonymous /embed/* and /api/auth/embed/token

### DIFF
--- a/k8s/apps/chat/authorizationpolicy-chat.yaml
+++ b/k8s/apps/chat/authorizationpolicy-chat.yaml
@@ -1,0 +1,64 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: chat-authz-policy
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    project: bootsandcats
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      app: chat-backend
+  rules:
+    # Authenticated principals from the trusted issuer may do anything.
+    - from:
+        - source:
+            requestPrincipals:
+              - https://roauth2.cat-herding.net/*
+    # Probes and metrics are open to the in-cluster control plane.
+    - to:
+        - operation:
+            paths:
+              - /api/health
+              - /health
+              - /healthz
+              - /metrics
+              - /api/docs*
+              - /docs*
+    # Socket.IO handshake + polling; the widget connects here after
+    # sign-in with the Bearer token in the handshake, but anonymous
+    # connects are also accepted for embed-without-auth hosts.
+    - to:
+        - operation:
+            paths:
+              - /api/socket.io*
+              - /api/socket.io/*
+    # SPA shell and static assets.
+    - to:
+        - operation:
+            methods: [GET, HEAD, OPTIONS]
+            paths:
+              - /
+              - /index.html
+              - /assets/*
+              - /static/*
+              - /_expo/*
+    # Embed widget bundle + popup callback. These must be publicly
+    # fetchable from any host page — the drop-in <script src=...>
+    # that mounts the widget, and the popup callback that receives
+    # the OAuth2 authorization_code redirect from roauth2.
+    - to:
+        - operation:
+            methods: [GET, HEAD, OPTIONS]
+            paths:
+              - /embed/*
+    # PKCE token-exchange proxy the widget calls during sign-in.
+    # The caller has no principal yet — that is the whole point of
+    # this endpoint. Scoped narrowly to POST on the exact path.
+    - to:
+        - operation:
+            methods: [POST, OPTIONS]
+            paths:
+              - /api/auth/embed/token

--- a/k8s/apps/chat/envoyfilter-chat-oauth2-exchange.yaml
+++ b/k8s/apps/chat/envoyfilter-chat-oauth2-exchange.yaml
@@ -126,3 +126,17 @@ spec:
                   prefix_match: '/assets/'
                 - name: ':path'
                   prefix_match: '/_expo'
+                # Embed widget bundle + popup callback must be publicly
+                # servable; they are the drop-in script a host page loads
+                # *before* a user has any chat-session cookie, and the
+                # callback receives the `?code=…&state=…` redirect from
+                # roauth2 in a popup with no session yet.
+                - name: ':path'
+                  prefix_match: '/embed/'
+                # PKCE token-exchange proxy the widget calls from the
+                # browser during sign-in. The user has no session yet —
+                # that is literally what this endpoint is for. Gating it
+                # behind the Envoy OAuth2 filter would redirect the POST
+                # to the auth server and break the flow.
+                - name: ':path'
+                  prefix_match: '/api/auth/embed/'

--- a/k8s/apps/chat/kustomization.yaml
+++ b/k8s/apps/chat/kustomization.yaml
@@ -13,5 +13,6 @@ resources:
   - secret-provider-class.yaml
   - secret-provider-oauth2.yaml
   - requestauthentication-chat.yaml
+  - authorizationpolicy-chat.yaml
   - envoyfilter-chat-jwt-to-headers.yaml
   - envoyfilter-chat-oauth2-exchange.yaml


### PR DESCRIPTION
## Summary

Fixes: embed widget bundle at `https://chat.cat-herding.net/embed/cat-herding-chat.js` is currently 302-redirecting to `/_oauth2/start` for anonymous callers, so host pages (e.g. `cat-herding.net/chat`) can't load the script and the widget never initializes.

Two narrow k8s changes:

1. **`envoyfilter-chat-oauth2-exchange.yaml`** — add `/embed/` and `/api/auth/embed/` to the Envoy OAuth2 filter's `pass_through_matcher` so the script, popup callback, and PKCE token-exchange POST are not swept into the auth redirect.
2. **`authorizationpolicy-chat.yaml`** (new, added to kustomization) — codifies the existing live `chat-authz-policy` for this repo (currently only applied ad-hoc) and adds:
   - `GET/HEAD/OPTIONS /embed/*` — anonymous (host page needs the bundle + callback before a user has any session)
   - `POST/OPTIONS /api/auth/embed/token` — anonymous (the PKCE exchange the widget calls during sign-in)

## Why these endpoints must be anonymous

| Endpoint | Purpose | Session at call time |
|---|---|---|
| `/embed/cat-herding-chat.js` | IIFE bundle loaded by host page `<script src>` | None — widget hasn't rendered yet |
| `/embed/callback.html` | Popup landing page for `redirect_uri` after `/oauth/authorize` | None — user just came back from roauth2 |
| `/api/auth/embed/token` | Same-origin PKCE proxy that exchanges `code` for access_token | None — user is _mid_ sign-in |

All three are "before the user has a token" endpoints. Gating them behind the token-bearing auth filter is a deadlock.

## Security posture

- `/embed/*` serves only static JS/HTML built from `embed/`. No user data, no API, no mutation.
- `/api/auth/embed/token` is the PKCE proxy introduced in #191 — already public by design, already rate-limited per IP in the router, already strips `refresh_token` before returning to the browser. No client secret ever leaves the pod.
- Every authenticated user path is unchanged. The backend still requires a valid `https://roauth2.cat-herding.net` JWT with audience `chat-backend` for anything outside the three paths above plus the already-open set (health/metrics/Socket.IO/SPA shell).

## Test plan

- [ ] After rollout: `curl -sI https://chat.cat-herding.net/embed/cat-herding-chat.js` returns 200 + `content-type: application/javascript`
- [ ] `curl -sI https://chat.cat-herding.net/embed/callback.html` returns 200
- [ ] `curl -sI -X POST https://chat.cat-herding.net/api/auth/embed/token` returns 400 (missing body) not 302 (redirect to auth)
- [ ] Visit `https://cat-herding.net/chat`: floating bubble appears, Sign in opens popup, approve, popup closes, widget reconnects Socket.IO with Bearer
- [ ] Authenticated Socket.IO handshake still works end-to-end
- [ ] An **unauthenticated** request to `/api/conversations` or any other protected path still 403s (i.e. we didn't accidentally open the whole backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)