### PR TITLE
fix(flux): decouple chat-app from image-automation health check

### DIFF
--- a/k8s/flux/clusters/bigboy/chat-app.yaml
+++ b/k8s/flux/clusters/bigboy/chat-app.yaml
@@ -17,11 +17,13 @@ spec:
     # default `flux-system`.
     name: chat-app
   targetNamespace: default
-  # Reconcile the image-automation resources on the same cadence so
-  # Flux re-evaluates the ImagePolicy and commits tag bumps back to
-  # git when CI pushes a newer timestamped image.
-  dependsOn:
-    - name: chat-image-automation
+  # Decoupled from chat-image-automation — the ImageRepository's ACR
+  # pull secret (`acr-pull`) currently uses a short-lived
+  # `az acr login --expose-token` AAD token, which is CLI-scoped and
+  # not accepted by Docker's oauth2 token exchange. Until we swap in a
+  # service principal or wire workload-identity, image-automation
+  # health-checks time out; the app Kustomization must apply
+  # independently so ConfigMap + Deployment updates still land.
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -32,12 +34,15 @@ spec:
   interval: 1m0s
   path: ./k8s/flux/apps/chat
   prune: true
-  wait: true
+  # wait:false — the ImageRepository under this kustomization needs
+  # ACR credentials that we have not wired yet (see note on the
+  # `chat-app` Kustomization above). Without `wait: false` the
+  # kustomization blocks itself on its own health check and reports
+  # Ready=Unknown forever; with `wait: false` the resources get
+  # applied and ImageRepository surfaces the auth error via its own
+  # Ready condition, which is the correct escalation surface.
+  wait: false
   timeout: 2m0s
   sourceRef:
     kind: GitRepository
-    # Azure-managed FluxConfiguration provisions the GitRepository
-    # with the same name as the FluxConfiguration resource, so the
-    # source we reconcile against is `chat-app`, not the upstream-Flux
-    # default `flux-system`.
     name: chat-app


### PR DESCRIPTION
## Summary

After #202 merged, the `chat-app-chat-cluster` Flux Kustomization reconciled and created both nested Kustomizations, but `chat-app` is stuck on `dependency 'flux-system/chat-image-automation' is not ready` and `chat-image-automation` is stuck on its own health check.

Root cause: the `ImageRepository` scans ACR with the `acr-pull` docker-registry secret, which I seeded from `az acr login --expose-token`. That flow returns a short-lived AAD bearer token scoped to the `az` CLI, not a Docker oauth2 refresh token, so image-reflector-controller's registry probe returns `UNAUTHORIZED` on every scan:

> GET https://gabby.azurecr.io/oauth2/token?scope=repository%3Achat-backend%3Apull — UNAUTHORIZED: authentication required

Until we wire a service principal or workload-identity credential for Flux, image-automation will never reach Ready. That would be fine on its own — the scan errors are visible on the `ImageRepository` status — except:

1. `chat-image-automation.spec.wait: true` blocks the Kustomization's own Ready condition on those CRs' health.
2. `chat-app.spec.dependsOn: [chat-image-automation]` means the app Kustomization (and therefore the `LLM_TIERED=true` ConfigMap change) never reconciles.

This PR:

- Drops `chat-app`'s `dependsOn` so app manifests apply independently.
- Flips `chat-image-automation` to `wait: false` so the Kustomization itself reports Ready once it applies the two CRs. The registry auth failure stays visible on the `ImageRepository` resource — the right escalation surface.

## Follow-up

Swap `acr-pull` for one of:
- Service principal: `kubectl create secret docker-registry acr-pull --docker-username=<sp-app-id> --docker-password=<sp-secret>` after granting it AcrPull.
- Workload identity: bind a ServiceAccount used by image-reflector-controller to an AAD identity with AcrPull.

## Test plan

- [ ] `flux reconcile kustomization chat-app-chat-cluster -n flux-system`
- [ ] `flux get kustomizations -A` → `chat-app` and `chat-image-automation` both Ready=True
- [ ] `kubectl -n default get configmap chat-backend-config -o jsonpath='{.data.LLM_TIERED}'` → `true`
- [ ] `kubectl -n flux-system get imagerepository chat-backend` still surfaces auth error on its own condition (expected, will be fixed by follow-up credential swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)