### PR TITLE
feat(auth): anon-friendly /me + sign-in banner in Expo frontend

### DIFF
--- a/backend/src/routes/__tests__/auth.test.ts
+++ b/backend/src/routes/__tests__/auth.test.ts
@@ -62,3 +62,45 @@ describe('GET /api/auth/session', () => {
     expect(res.body.loginUrl).toBeNull();
   });
 });
+
+describe('GET /api/auth/me (anon-friendly)', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(cookieParser());
+    app.use(express.json());
+    app.use('/api/auth', authRoutes);
+  });
+
+  afterEach(() => {
+    delete process.env.LOGIN_URL;
+  });
+
+  it('returns user:null + tier=anonymous for unauthenticated callers (no 401)', async () => {
+    const res = await request(app).get('/api/auth/me');
+
+    expect(res.status).toBe(200);
+    expect(res.body.user).toBeNull();
+    expect(res.body.tier).toBe('anonymous');
+    expect(res.body.authenticated).toBe(false);
+    expect(res.body.loginUrl).toBe('/oauth2/start');
+  });
+
+  it('returns user + tier=authenticated when Istio headers are present', async () => {
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('x-auth-subject', 'subject-xyz')
+      .set('x-auth-email', 'alice@example.com')
+      .set('x-auth-name', 'Alice');
+
+    expect(res.status).toBe(200);
+    expect(res.body.tier).toBe('authenticated');
+    expect(res.body.authenticated).toBe(true);
+    expect(res.body.user).toMatchObject({
+      email: 'alice@example.com',
+      name: 'Alice',
+    });
+    expect(res.body.loginUrl).toBeNull();
+  });
+});

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,4 @@
 import { Router, Request, Response } from 'express';
-import { authenticateToken } from '../middleware/auth';
 import { resolveIdentity } from '../middleware/identity';
 import { logger } from '../logger';
 
@@ -46,33 +45,37 @@ router.get('/session', resolveIdentity, (req: Request, res: Response): void => {
  * @swagger
  * /api/auth/me:
  *   get:
- *     summary: Get current user profile
- *     description: Returns user information from oauth2-proxy headers when authenticated at cluster level
+ *     summary: Get current user profile (degrades to anon)
+ *     description: >
+ *       Returns the caller's tier snapshot. Authenticated callers get a
+ *       user object populated from Istio headers; anonymous callers get
+ *       `user: null` plus tier/loginUrl so the frontend can render a
+ *       sign-in CTA without crashing on 401.
  *     tags: [Authentication]
  *     responses:
  *       200:
- *         description: User profile (from oauth2-proxy headers)
- *       401:
- *         description: Not authenticated
+ *         description: Session snapshot (user null when anonymous)
  */
-router.get('/me', authenticateToken, (req: Request, res: Response): void => {
-  const user = req.user;
-
-  if (!user) {
-    res.status(401).json({ error: 'Not authenticated' });
-    return;
-  }
+router.get('/me', resolveIdentity, (req: Request, res: Response): void => {
+  const tier = req.tier ?? 'anonymous';
+  const authenticated = tier === 'authenticated';
+  const user = authenticated ? req.user : null;
 
   res.json({
-    user: {
-      id: user.id,
-      email: user.email,
-      name: user.name,
-      avatar: user.avatar,
-      provider: user.provider,
-      createdAt: user.createdAt,
-      lastLoginAt: user.lastLoginAt,
-    },
+    user: user
+      ? {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          avatar: user.avatar,
+          provider: user.provider,
+          createdAt: user.createdAt,
+          lastLoginAt: user.lastLoginAt,
+        }
+      : null,
+    tier,
+    authenticated,
+    loginUrl: authenticated ? null : process.env.LOGIN_URL || '/oauth2/start',
   });
 });
 

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -10,6 +10,7 @@ import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { AuthProvider } from '@/components/AuthProvider';
+import { LoginBanner } from '@/components/LoginBanner';
 
 /**
  * RootLayout - Main app layout
@@ -31,6 +32,7 @@ export default function RootLayout() {
   return (
     <AuthProvider>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <LoginBanner />
         <Stack>
           <Stack.Screen name='(tabs)' options={{ headerShown: false }} />
           <Stack.Screen name='+not-found' />

--- a/frontend/components/LoginBanner.tsx
+++ b/frontend/components/LoginBanner.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Linking,
+  Platform,
+} from 'react-native';
+
+interface SessionSnapshot {
+  tier: 'anonymous' | 'authenticated';
+  authenticated: boolean;
+  loginUrl: string | null;
+}
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
+
+/**
+ * LoginBanner — shows "Sign in for smarter agents" CTA for anon callers.
+ * Fetches /api/auth/me which always returns 200 with a session snapshot.
+ * Hides itself when the caller is authenticated.
+ */
+export function LoginBanner() {
+  const [session, setSession] = useState<SessionSnapshot | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${API_URL}/api/auth/me`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (cancelled || !data) return;
+        setSession({
+          tier: data.tier ?? 'anonymous',
+          authenticated: Boolean(data.authenticated),
+          loginUrl: data.loginUrl ?? '/oauth2/start',
+        });
+      })
+      .catch(() => {
+        /* network error — stay hidden */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!session || session.authenticated || dismissed) return null;
+
+  const href = session.loginUrl ?? '/oauth2/start';
+  const fullHref = href.startsWith('http') ? href : `${API_URL}${href}`;
+
+  const handlePress = () => {
+    if (Platform.OS === 'web') {
+      window.location.href = fullHref;
+    } else {
+      Linking.openURL(fullHref);
+    }
+  };
+
+  return (
+    <View style={styles.banner} accessibilityRole='alert'>
+      <Text style={styles.text}>
+        You’re chatting as a guest on the free-tier model.{' '}
+        <Text style={styles.link} onPress={handlePress}>
+          Sign in
+        </Text>{' '}
+        for smarter agents and higher limits.
+      </Text>
+      <Pressable
+        onPress={() => setDismissed(true)}
+        accessibilityLabel='Dismiss sign-in banner'
+        style={styles.dismiss}
+      >
+        <Text style={styles.dismissText}>×</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    backgroundColor: '#1a2a20',
+    borderBottomWidth: 1,
+    borderBottomColor: '#2a3a2e',
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  text: {
+    color: '#e8f0e8',
+    fontSize: 13,
+    flex: 1,
+  },
+  link: {
+    color: '#4a9a6a',
+    fontWeight: '600',
+    textDecorationLine: 'underline',
+  },
+  dismiss: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  dismissText: {
+    color: '#9cb2a0',
+    fontSize: 20,
+    lineHeight: 20,
+  },
+});

--- a/frontend/services/authService.ts
+++ b/frontend/services/authService.ts
@@ -95,7 +95,16 @@ class AuthService {
   }
 
   /**
-   * Fetch current user from API
+   * Fetch current user from API.
+   *
+   * `/api/auth/me` now always returns 200 and degrades gracefully: for
+   * anonymous callers the response carries `user: null` plus a tier
+   * snapshot (`tier`, `authenticated`, `loginUrl`). That's intentional —
+   * the cluster-level oauth2-proxy no longer redirects chat.cat-herding
+   * requests on 401, and the backend mints an _chat_anon cookie so the
+   * frontend can operate without a signed-in user.
+   *
+   * Non-ok responses (5xx, network) still return null quietly.
    */
   async fetchCurrentUser(token?: string | null): Promise<User | null> {
     try {
@@ -110,13 +119,16 @@ class AuthService {
       });
 
       if (!response.ok) {
-        throw new Error('Failed to fetch user');
+        // 5xx / network noise — stay silent, anon fallback kicks in.
+        return null;
       }
 
       const data = await response.json();
-      return data.user;
+      return data.user ?? null;
     } catch (error) {
-      console.error('Error fetching current user:', error);
+      if (__DEV__) {
+        console.warn('fetchCurrentUser failed; treating as anonymous', error);
+      }
       return null;
     }
   }


### PR DESCRIPTION
Fixes the console errors reported against the live Expo frontend:

```
GET https://chat.cat-herding.net/api/auth/me 401 (Unauthorized)
Error fetching current user: Error: Failed to fetch user
```

and the missing "sign in for better chat" banner.

## Changes

**Backend** — `/api/auth/me` now uses `resolveIdentity` and always returns 200. Authed callers get the `user` object (unchanged shape); anon callers get `user: null` plus `tier`, `authenticated`, `loginUrl`. No more 401. Tests added.

**Frontend** — new `LoginBanner` component, rendered once in `_layout.tsx`. Fetches `/me`, shows a dismissable "Sign in for smarter agents and higher limits" CTA when `authenticated === false`, hides otherwise. `fetchCurrentUser` no longer throws on non-2xx — returns null silently so the React tree doesn't tear.

## Test plan

- [x] `npx jest --runInBand` backend suite: 467/467 passing
- [x] New `/api/auth/me` tests cover anon (200 + `user: null`) and authed (200 + user populated)
- [ ] After deploy: visit `https://chat.cat-herding.net` unauthenticated → banner visible, no console errors; click sign-in → `/oauth2/start` flow; after sign-in the banner hides.

## Follow-up

`/api/auth/session` and `/api/auth/me` now return identical shapes. Consider consolidating the frontend to one endpoint in a later pass.